### PR TITLE
Add friends presence application skeletons

### DIFF
--- a/DTOs/Friends/FriendDto.cs
+++ b/DTOs/Friends/FriendDto.cs
@@ -1,0 +1,7 @@
+namespace DTOs.Friends;
+
+public sealed record FriendDto(
+    Guid Id,
+    UserBriefDto User,
+    DateTime? BecameFriendsAtUtc
+);

--- a/DTOs/Friends/FriendRequestsDto.cs
+++ b/DTOs/Friends/FriendRequestsDto.cs
@@ -1,0 +1,8 @@
+namespace DTOs.Friends;
+
+public sealed record FriendRequestsDto(
+    Guid Id,
+    UserBriefDto Requester,
+    UserBriefDto Addressee,
+    DateTime RequestedAtUtc
+);

--- a/DTOs/Friends/SuggestedFriendDto.cs
+++ b/DTOs/Friends/SuggestedFriendDto.cs
@@ -1,0 +1,6 @@
+namespace DTOs.Friends;
+
+public sealed record SuggestedFriendDto(
+    UserBriefDto User,
+    int MutualFriendsCount
+);

--- a/DTOs/Friends/UserBriefDto.cs
+++ b/DTOs/Friends/UserBriefDto.cs
@@ -1,0 +1,7 @@
+namespace DTOs.Friends;
+
+public sealed record UserBriefDto(
+    Guid Id,
+    string UserName,
+    string? AvatarUrl
+);

--- a/Services/Application/Friends/IFriendService.cs
+++ b/Services/Application/Friends/IFriendService.cs
@@ -1,0 +1,29 @@
+namespace Application.Friends;
+
+public interface IFriendService
+{
+    Task<BusinessObjects.Common.Results.Result> InviteAsync(
+        Guid requesterId,
+        Guid targetUserId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result> AcceptAsync(
+        Guid requesterId,
+        Guid targetUserId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result> DeclineAsync(
+        Guid requesterId,
+        Guid targetUserId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result> CancelAsync(
+        Guid requesterId,
+        Guid targetUserId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result<BusinessObjects.Common.Pagination.CursorPageResult<DTOs.Friends.FriendDto>>> ListAsync(
+        Guid requesterId,
+        BusinessObjects.Common.Pagination.CursorRequest request,
+        CancellationToken ct = default);
+}

--- a/Services/Application/Friends/IPresenceService.cs
+++ b/Services/Application/Friends/IPresenceService.cs
@@ -1,0 +1,16 @@
+namespace Application.Friends;
+
+public interface IPresenceService
+{
+    Task<BusinessObjects.Common.Results.Result> HeartbeatAsync(
+        Guid userId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result<bool>> IsOnlineAsync(
+        Guid userId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result<IReadOnlyDictionary<Guid, bool>>> BatchIsOnlineAsync(
+        IReadOnlyCollection<Guid> userIds,
+        CancellationToken ct = default);
+}

--- a/Services/GlobalUsing.cs
+++ b/Services/GlobalUsing.cs
@@ -2,6 +2,7 @@
 global using BusinessObjects.Common;
 global using BusinessObjects.Common.Pagination;
 global using BusinessObjects.Common.Results;
+global using DTOs.Friends;
 global using DTOs.Auth;
 global using DTOs.Auth.Requests;
 global using DTOs.Auth.Validation;


### PR DESCRIPTION
## Summary
- add friend and presence service contracts under the Application.Friends namespace
- introduce friends DTO skeletons for future implementation and wire up global usings

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b39a6b14832d9db5c4450a58d36e