### PR TITLE
Add Redis-backed presence heartbeat hub

### DIFF
--- a/DTOs/Friends/FriendDto.cs
+++ b/DTOs/Friends/FriendDto.cs
@@ -1,0 +1,7 @@
+namespace DTOs.Friends;
+
+public sealed record FriendDto(
+    Guid Id,
+    UserBriefDto User,
+    DateTime? BecameFriendsAtUtc
+);

--- a/DTOs/Friends/FriendRequestsDto.cs
+++ b/DTOs/Friends/FriendRequestsDto.cs
@@ -1,0 +1,8 @@
+namespace DTOs.Friends;
+
+public sealed record FriendRequestsDto(
+    Guid Id,
+    UserBriefDto Requester,
+    UserBriefDto Addressee,
+    DateTime RequestedAtUtc
+);

--- a/DTOs/Friends/SuggestedFriendDto.cs
+++ b/DTOs/Friends/SuggestedFriendDto.cs
@@ -1,0 +1,6 @@
+namespace DTOs.Friends;
+
+public sealed record SuggestedFriendDto(
+    UserBriefDto User,
+    int MutualFriendsCount
+);

--- a/DTOs/Friends/UserBriefDto.cs
+++ b/DTOs/Friends/UserBriefDto.cs
@@ -1,0 +1,7 @@
+namespace DTOs.Friends;
+
+public sealed record UserBriefDto(
+    Guid Id,
+    string UserName,
+    string? AvatarUrl
+);

--- a/Services/Application/Friends/IFriendService.cs
+++ b/Services/Application/Friends/IFriendService.cs
@@ -1,0 +1,29 @@
+namespace Application.Friends;
+
+public interface IFriendService
+{
+    Task<BusinessObjects.Common.Results.Result> InviteAsync(
+        Guid requesterId,
+        Guid targetUserId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result> AcceptAsync(
+        Guid requesterId,
+        Guid targetUserId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result> DeclineAsync(
+        Guid requesterId,
+        Guid targetUserId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result> CancelAsync(
+        Guid requesterId,
+        Guid targetUserId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result<BusinessObjects.Common.Pagination.CursorPageResult<DTOs.Friends.FriendDto>>> ListAsync(
+        Guid requesterId,
+        BusinessObjects.Common.Pagination.CursorRequest request,
+        CancellationToken ct = default);
+}

--- a/Services/Application/Friends/IPresenceService.cs
+++ b/Services/Application/Friends/IPresenceService.cs
@@ -1,0 +1,16 @@
+namespace Application.Friends;
+
+public interface IPresenceService
+{
+    Task<BusinessObjects.Common.Results.Result> HeartbeatAsync(
+        Guid userId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result<bool>> IsOnlineAsync(
+        Guid userId,
+        CancellationToken ct = default);
+
+    Task<BusinessObjects.Common.Results.Result<IReadOnlyDictionary<Guid, bool>>> BatchIsOnlineAsync(
+        IReadOnlyCollection<Guid> userIds,
+        CancellationToken ct = default);
+}

--- a/Services/Common/DependencyInjection/DependencyInjection.cs
+++ b/Services/Common/DependencyInjection/DependencyInjection.cs
@@ -1,6 +1,7 @@
 ﻿using FluentValidation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Services.Presence;
 using System.Reflection;
 
 namespace Services.Common.DependencyInjection
@@ -32,6 +33,11 @@ namespace Services.Common.DependencyInjection
                 services.AddOptions<GoogleAuthOptions>()
                         .Bind(configuration.GetSection(GoogleAuthOptions.SectionName))
                         .Validate(o => !string.IsNullOrWhiteSpace(o.ClientId), "GoogleAuth:ClientId is required")
+                        .ValidateOnStart();
+                services.AddOptions<PresenceOptions>()
+                        .Bind(configuration.GetSection(PresenceOptions.SectionName))
+                        .Validate(o => o.TtlSeconds > 0, "Presence:TtlSeconds must be positive")
+                        .Validate(o => o.HeartbeatSeconds > 0, "Presence:HeartbeatSeconds must be positive")
                         .ValidateOnStart();
                 // KHÔNG đăng ký singleton .Value để giữ hot-reload
             }

--- a/Services/GlobalUsing.cs
+++ b/Services/GlobalUsing.cs
@@ -2,6 +2,7 @@
 global using BusinessObjects.Common;
 global using BusinessObjects.Common.Pagination;
 global using BusinessObjects.Common.Results;
+global using DTOs.Friends;
 global using DTOs.Auth;
 global using DTOs.Auth.Requests;
 global using DTOs.Auth.Validation;

--- a/Services/Presence/PresenceOptions.cs
+++ b/Services/Presence/PresenceOptions.cs
@@ -1,0 +1,10 @@
+namespace Services.Presence;
+
+public sealed class PresenceOptions
+{
+    public const string SectionName = "Presence";
+
+    public int TtlSeconds { get; init; } = 60;
+
+    public int HeartbeatSeconds { get; init; } = 30;
+}

--- a/WebAPI/Hubs/PresenceHub.cs
+++ b/WebAPI/Hubs/PresenceHub.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
+using Services.Presence;
+using StackExchange.Redis;
+
+namespace WebAPI.Hubs;
+
+[Authorize]
+public sealed class PresenceHub : Hub
+{
+    private readonly IConnectionMultiplexer _redis;
+    private readonly PresenceOptions _options;
+
+    public PresenceHub(IConnectionMultiplexer redis, IOptions<PresenceOptions> options)
+    {
+        _redis = redis;
+        _options = options.Value;
+    }
+
+    public async Task Heartbeat()
+    {
+        var userId = Context.User.GetUserId();
+        if (userId is null)
+        {
+            throw new HubException("Authenticated user required for heartbeat");
+        }
+
+        var ttl = TimeSpan.FromSeconds(_options.TtlSeconds);
+        var timestamp = DateTimeOffset.UtcNow.ToString("O");
+        var db = _redis.GetDatabase();
+
+        await Task.WhenAll(
+            db.StringSetAsync($"presence:{userId}", "1", ttl),
+            db.StringSetAsync($"lastseen:{userId}", timestamp));
+    }
+}

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -1,4 +1,6 @@
-﻿var builder = WebApplication.CreateBuilder(args);
+using WebAPI.Hubs;
+
+var builder = WebApplication.CreateBuilder(args);
 
 builder.AddObservability();
 // Data Protection: bắt buộc khi dùng AddDefaultTokenProviders()
@@ -27,5 +29,7 @@ var app = builder.Build();
 // UseWebApi xử lý các vấn đề của khung sườn API (lỗi, OpenAPI, HTTPS, CORS, Auth, Controllers).
 app.UseOperationalPipeline(app.Environment);
 app.UseWebApi(app.Environment);
+
+app.MapHub<PresenceHub>("/ws/presence");
 
 app.Run();

--- a/WebAPI/WebAPI.csproj
+++ b/WebAPI/WebAPI.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
   </ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.9" />

--- a/WebAPI/appsettings.Development.json
+++ b/WebAPI/appsettings.Development.json
@@ -46,5 +46,12 @@
   "GoogleAuth": {
     "ClientId": "YOUR_GOOGLE_OAUTH_CLIENT_ID.apps.googleusercontent.com",
     "AllowedHostedDomain": ""
+  },
+  "Presence": {
+    "TtlSeconds": 60,
+    "HeartbeatSeconds": 30
+  },
+  "Redis": {
+    "ConnectionString": ""
   }
 }

--- a/WebAPI/appsettings.json
+++ b/WebAPI/appsettings.json
@@ -5,5 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Presence": {
+    "TtlSeconds": 60,
+    "HeartbeatSeconds": 30
+  },
+  "Redis": {
+    "ConnectionString": ""
+  }
 }


### PR DESCRIPTION
## Summary
- register StackExchange.Redis and bind presence options with TTL and heartbeat settings
- add an authorized SignalR presence hub that refreshes presence and last seen keys on heartbeat
- expose the presence hub endpoint and configuration defaults for TTL and heartbeat intervals

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b39a6b14832d9db5c4450a58d36e