### PR TITLE
Implement PresenceService with Redis heartbeat

### DIFF
--- a/Services/Presence/PresenceService.cs
+++ b/Services/Presence/PresenceService.cs
@@ -1,0 +1,104 @@
+using Application.Friends;
+using BusinessObjects.Common.Results;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace Services.Presence;
+
+public sealed class PresenceService : IPresenceService
+{
+    private readonly IConnectionMultiplexer _redis;
+    private readonly PresenceOptions _options;
+
+    public PresenceService(IConnectionMultiplexer redis, IOptions<PresenceOptions> options)
+    {
+        _redis = redis;
+        _options = options.Value;
+    }
+
+    public Task<Result> HeartbeatAsync(Guid userId, CancellationToken ct = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            return Task.FromResult(Result.Failure(new Error(Error.Codes.Validation, "User id is required")));
+        }
+
+        return ResultExtensions
+            .TryAsync(async () =>
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var ttl = TimeSpan.FromSeconds(_options.TtlSeconds);
+                var timestamp = DateTimeOffset.UtcNow.ToString("O");
+                var db = _redis.GetDatabase();
+
+                await Task
+                    .WhenAll(
+                        db.StringSetAsync(GetPresenceKey(userId), "1", ttl),
+                        db.StringSetAsync(GetLastSeenKey(userId), timestamp))
+                    .ConfigureAwait(false);
+
+                return true;
+            })
+            .ToResult();
+    }
+
+    public Task<Result<bool>> IsOnlineAsync(Guid userId, CancellationToken ct = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            return Task.FromResult(Result<bool>.Failure(new Error(Error.Codes.Validation, "User id is required")));
+        }
+
+        return ResultExtensions.TryAsync(async () =>
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var db = _redis.GetDatabase();
+            var key = GetPresenceKey(userId);
+            var exists = await db.KeyExistsAsync(key).ConfigureAwait(false);
+            return exists;
+        });
+    }
+
+    public Task<Result<IReadOnlyDictionary<Guid, bool>>> BatchIsOnlineAsync(
+        IReadOnlyCollection<Guid> userIds,
+        CancellationToken ct = default)
+    {
+        if (userIds is null)
+        {
+            return Task.FromResult(Result<IReadOnlyDictionary<Guid, bool>>.Failure(
+                new Error(Error.Codes.Validation, "User ids are required")));
+        }
+
+        return ResultExtensions.TryAsync(async () =>
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var distinctIds = userIds.Where(id => id != Guid.Empty).Distinct().ToArray();
+            if (distinctIds.Length == 0)
+            {
+                return (IReadOnlyDictionary<Guid, bool>)new Dictionary<Guid, bool>();
+            }
+
+            var db = _redis.GetDatabase();
+            var batch = db.CreateBatch();
+            var tasks = new Dictionary<Guid, Task<bool>>(distinctIds.Length);
+
+            foreach (var id in distinctIds)
+            {
+                var key = GetPresenceKey(id);
+                tasks[id] = batch.KeyExistsAsync(key);
+            }
+
+            await batch.ExecuteAsync().ConfigureAwait(false);
+            await Task.WhenAll(tasks.Values).ConfigureAwait(false);
+
+            var result = tasks.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Result);
+            return (IReadOnlyDictionary<Guid, bool>)result;
+        });
+    }
+
+    private static RedisKey GetPresenceKey(Guid userId) => $"presence:{userId}";
+    private static RedisKey GetLastSeenKey(Guid userId) => $"lastseen:{userId}";
+}

--- a/StudentGamerHub.sln
+++ b/StudentGamerHub.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services", "Services\Servic
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI", "WebAPI\WebAPI.csproj", "{0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services.Presence.Tests", "Tests\Services.Presence.Tests\Services.Presence.Tests.csproj", "{E319488C-64A9-42F3-BE29-95BC0891084C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,10 +38,14 @@ Global
 		{6E2D02EC-69D0-494F-A351-3D92EAC09C4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6E2D02EC-69D0-494F-A351-3D92EAC09C4E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E319488C-64A9-42F3-BE29-95BC0891084C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E319488C-64A9-42F3-BE29-95BC0891084C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E319488C-64A9-42F3-BE29-95BC0891084C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E319488C-64A9-42F3-BE29-95BC0891084C}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Tests/Services.Presence.Tests/PresenceServiceTests.cs
+++ b/Tests/Services.Presence.Tests/PresenceServiceTests.cs
@@ -1,0 +1,123 @@
+using Application.Friends;
+using BusinessObjects.Common.Results;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Services.Presence;
+using StackExchange.Redis;
+
+namespace Services.Presence.Tests;
+
+public sealed class PresenceServiceTests
+{
+    private readonly IConnectionMultiplexer _connection = Substitute.For<IConnectionMultiplexer>();
+    private readonly IDatabase _database = Substitute.For<IDatabase>();
+    private readonly IBatch _batch = Substitute.For<IBatch>();
+    private readonly PresenceOptions _options = new() { TtlSeconds = 60, HeartbeatSeconds = 30 };
+    private readonly Dictionary<string, CacheEntry> _store = new(StringComparer.Ordinal);
+    private readonly PresenceService _service;
+
+    public PresenceServiceTests()
+    {
+        _connection.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(_database);
+        _database.CreateBatch(Arg.Any<object>()).Returns(_batch);
+
+        _database.StringSetAsync(
+            Arg.Any<RedisKey>(),
+            Arg.Any<RedisValue>(),
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<When>(),
+            Arg.Any<CommandFlags>())
+        .Returns(ci =>
+        {
+            var key = ci.Arg<RedisKey>().ToString();
+            var expiry = ci.Arg<TimeSpan?>();
+            var value = ci.Arg<RedisValue>().ToString();
+            _store[key] = new CacheEntry(value, expiry.HasValue ? DateTimeOffset.UtcNow.Add(expiry.Value) : null);
+            return Task.FromResult(true);
+        });
+
+        _database.KeyExistsAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(ci => Task.FromResult(IsAlive(ci.Arg<RedisKey>().ToString())));
+
+        _batch.KeyExistsAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(ci => Task.FromResult(IsAlive(ci.Arg<RedisKey>().ToString())));
+
+        _batch.ExecuteAsync(Arg.Any<CommandFlags>()).Returns(Task.CompletedTask);
+
+        _service = new PresenceService(_connection, Options.Create(_options));
+    }
+
+    [Fact]
+    public async Task HeartbeatAsync_ShouldSetPresenceKeyWithTtl()
+    {
+        var userId = Guid.NewGuid();
+
+        var result = await _service.HeartbeatAsync(userId);
+
+        result.IsSuccess.Should().BeTrue();
+        _store.TryGetValue($"presence:{userId}", out var entry).Should().BeTrue();
+        entry!.ExpiresAt.Should().NotBeNull();
+        entry.ExpiresAt!.Value.Should().BeCloseTo(DateTimeOffset.UtcNow.AddSeconds(_options.TtlSeconds), TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task BatchIsOnlineAsync_ShouldReturnOnlineAndOfflineUsers()
+    {
+        var onlineUsers = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+        var offlineUsers = new[] { Guid.NewGuid(), Guid.NewGuid() };
+
+        foreach (var user in onlineUsers)
+        {
+            await _service.HeartbeatAsync(user);
+        }
+
+        var users = onlineUsers.Concat(offlineUsers).ToArray();
+
+        var result = await _service.BatchIsOnlineAsync(users);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        foreach (var user in onlineUsers)
+        {
+            result.Value![user].Should().BeTrue();
+        }
+
+        foreach (var user in offlineUsers)
+        {
+            result.Value![user].Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public async Task IsOnlineAsync_ShouldReturnFalseAfterTtlExpires()
+    {
+        var userId = Guid.NewGuid();
+        await _service.HeartbeatAsync(userId);
+
+        var key = $"presence:{userId}";
+        _store[key] = _store[key] with { ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(-1) };
+
+        var result = await _service.IsOnlineAsync(userId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+    }
+
+    private bool IsAlive(string key)
+    {
+        if (!_store.TryGetValue(key, out var entry))
+        {
+            return false;
+        }
+
+        if (entry.ExpiresAt is null)
+        {
+            return true;
+        }
+
+        return entry.ExpiresAt > DateTimeOffset.UtcNow;
+    }
+
+    private sealed record CacheEntry(string Value, DateTimeOffset? ExpiresAt);
+}

--- a/Tests/Services.Presence.Tests/Services.Presence.Tests.csproj
+++ b/Tests/Services.Presence.Tests/Services.Presence.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Services\Services.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add a Redis-backed PresenceService implementing heartbeat, online lookup, and batch status queries
- register a new test project exercising presence checks and TTL behavior

## Testing
- dotnet test StudentGamerHub.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e62514baa8832dad035db4aa2075a5