### PR TITLE
Add friends API endpoints with rate limiting and docs

### DIFF
--- a/Services/Application/Friends/FriendsFilter.cs
+++ b/Services/Application/Friends/FriendsFilter.cs
@@ -1,0 +1,9 @@
+namespace Application.Friends;
+
+public enum FriendsFilter
+{
+    All,
+    Online,
+    Requests,
+    Suggested
+}

--- a/Services/Application/Friends/IFriendService.cs
+++ b/Services/Application/Friends/IFriendService.cs
@@ -24,6 +24,7 @@ public interface IFriendService
 
     Task<BusinessObjects.Common.Results.Result<BusinessObjects.Common.Pagination.CursorPageResult<DTOs.Friends.FriendDto>>> ListAsync(
         Guid requesterId,
+        FriendsFilter filter,
         BusinessObjects.Common.Pagination.CursorRequest request,
         CancellationToken ct = default);
 }

--- a/Services/Common/Mapping/UserMappers.cs
+++ b/Services/Common/Mapping/UserMappers.cs
@@ -4,6 +4,44 @@ namespace Services.Common.Mapping
 {
     public static class UserMappers
     {
+        public static UserBriefDto ToUserBriefDto(this User user)
+        {
+            ArgumentNullException.ThrowIfNull(user);
+
+            return new UserBriefDto(
+                Id: user.Id,
+                UserName: user.UserName ?? string.Empty,
+                AvatarUrl: user.AvatarUrl
+            );
+        }
+
+        public static FriendDto ToFriendDtoFor(this FriendLink link, Guid requesterId)
+        {
+            ArgumentNullException.ThrowIfNull(link);
+
+            if (link.SenderId == requesterId)
+            {
+                ArgumentNullException.ThrowIfNull(link.Recipient);
+                return new FriendDto(
+                    Id: link.Id,
+                    User: link.Recipient.ToUserBriefDto(),
+                    BecameFriendsAtUtc: link.RespondedAt?.UtcDateTime
+                );
+            }
+
+            if (link.RecipientId == requesterId)
+            {
+                ArgumentNullException.ThrowIfNull(link.Sender);
+                return new FriendDto(
+                    Id: link.Id,
+                    User: link.Sender.ToUserBriefDto(),
+                    BecameFriendsAtUtc: link.RespondedAt?.UtcDateTime
+                );
+            }
+
+            throw new InvalidOperationException("Requester must be associated with the friend link.");
+        }
+
         /// <summary>
         /// Map entity -> UserListItemDto (UTC -> VN khi hiển thị).
         /// </summary>

--- a/WebAPI/Controllers/FriendsController.cs
+++ b/WebAPI/Controllers/FriendsController.cs
@@ -1,0 +1,147 @@
+using Application.Friends;
+using DTOs.Friends;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace WebApi.Controllers
+{
+    [ApiController]
+    [Route("friends")]
+    [Produces("application/json")]
+    [Authorize]
+    public sealed class FriendsController : ControllerBase
+    {
+        private readonly IFriendService _svc;
+
+        public FriendsController(IFriendService svc)
+        {
+            _svc = svc ?? throw new ArgumentNullException(nameof(svc));
+        }
+
+        [HttpPost("{userId:guid}/invite")]
+        [EnableRateLimiting("FriendInvite")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult> Invite(Guid userId, CancellationToken ct)
+        {
+            var currentUserId = User.GetUserId();
+            if (!currentUserId.HasValue)
+            {
+                return this.ToActionResult(Result.Failure(
+                    new Error(Error.Codes.Unauthorized, "User identity is required.")));
+            }
+
+            var result = await _svc.InviteAsync(currentUserId.Value, userId, ct).ConfigureAwait(false);
+            return this.ToActionResult(result);
+        }
+
+        [HttpPost("{userId:guid}/accept")]
+        [EnableRateLimiting("FriendAction")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult> Accept(Guid userId, CancellationToken ct)
+        {
+            var currentUserId = User.GetUserId();
+            if (!currentUserId.HasValue)
+            {
+                return this.ToActionResult(Result.Failure(
+                    new Error(Error.Codes.Unauthorized, "User identity is required.")));
+            }
+
+            var result = await _svc.AcceptAsync(currentUserId.Value, userId, ct).ConfigureAwait(false);
+            return this.ToActionResult(result);
+        }
+
+        [HttpPost("{userId:guid}/decline")]
+        [EnableRateLimiting("FriendAction")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult> Decline(Guid userId, CancellationToken ct)
+        {
+            var currentUserId = User.GetUserId();
+            if (!currentUserId.HasValue)
+            {
+                return this.ToActionResult(Result.Failure(
+                    new Error(Error.Codes.Unauthorized, "User identity is required.")));
+            }
+
+            var result = await _svc.DeclineAsync(currentUserId.Value, userId, ct).ConfigureAwait(false);
+            return this.ToActionResult(result);
+        }
+
+        [HttpPost("{userId:guid}/cancel")]
+        [EnableRateLimiting("FriendAction")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult> Cancel(Guid userId, CancellationToken ct)
+        {
+            var currentUserId = User.GetUserId();
+            if (!currentUserId.HasValue)
+            {
+                return this.ToActionResult(Result.Failure(
+                    new Error(Error.Codes.Unauthorized, "User identity is required.")));
+            }
+
+            var result = await _svc.CancelAsync(currentUserId.Value, userId, ct).ConfigureAwait(false);
+            return this.ToActionResult(result);
+        }
+
+        [HttpGet]
+        [ProducesResponseType(typeof(CursorPageResult<FriendDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult> List([FromQuery(Name = "filter")] string? filter, [FromQuery] CursorRequest request, CancellationToken ct)
+        {
+            var currentUserId = User.GetUserId();
+            if (!currentUserId.HasValue)
+            {
+                var unauthorized = Result<CursorPageResult<FriendDto>>.Failure(
+                    new Error(Error.Codes.Unauthorized, "User identity is required."));
+                return this.ToActionResult(unauthorized, v => v, StatusCodes.Status200OK);
+            }
+
+            var parsedFilter = FriendsFilter.All;
+            if (!string.IsNullOrWhiteSpace(filter) && !Enum.TryParse(filter, true, out parsedFilter))
+            {
+                var allowed = string.Join(", ", Enum.GetNames<FriendsFilter>().Select(n => n.ToLowerInvariant()));
+                var failure = Result<CursorPageResult<FriendDto>>.Failure(
+                    new Error(Error.Codes.Validation, $"Invalid filter '{filter}'. Allowed values: {allowed}."));
+                return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
+            }
+
+            var result = await _svc.ListAsync(currentUserId.Value, parsedFilter, request, ct).ConfigureAwait(false);
+            return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+        }
+    }
+}

--- a/WebAPI/Extensions/ApplicationBuilderExtensions.cs
+++ b/WebAPI/Extensions/ApplicationBuilderExtensions.cs
@@ -8,17 +8,9 @@ public static class ApplicationBuilderExtensions
     {
         app.UseExceptionHandler();
 
-        if (env.IsDevelopment())
-        {
-            // 1) Xuất OpenAPI JSON
-            app.MapOpenApi();
-
-            // 2) Map Scalar UI (chọn route cố định, ví dụ /docs)
-            app.MapScalarApiReference("/docs", o => o.WithTitle("My API"));
-
-            // 3) Redirect trang gốc "/" -> "/docs" để mở UI ngay khi chạy
-            app.MapGet("/", () => Results.Redirect("/docs"));
-        }
+        app.MapOpenApi();
+        app.MapScalarApiReference("/docs", o => o.WithTitle("Student Gamer Hub API"));
+        app.MapGet("/", () => Results.Redirect("/docs"));
 
         app.UseHttpsRedirection();
         app.UseCors("Default");

--- a/WebAPI/Extensions/FriendsExamplesDocumentTransformer.cs
+++ b/WebAPI/Extensions/FriendsExamplesDocumentTransformer.cs
@@ -1,0 +1,155 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using System.Globalization;
+
+namespace WebAPI.Extensions
+{
+    public sealed class FriendsExamplesDocumentTransformer : IOpenApiDocumentTransformer
+    {
+        private static readonly string[] ErrorStatuses =
+        [
+            StatusCodes.Status400BadRequest.ToString(CultureInfo.InvariantCulture),
+            StatusCodes.Status401Unauthorized.ToString(CultureInfo.InvariantCulture),
+            StatusCodes.Status403Forbidden.ToString(CultureInfo.InvariantCulture),
+            StatusCodes.Status404NotFound.ToString(CultureInfo.InvariantCulture),
+            StatusCodes.Status409Conflict.ToString(CultureInfo.InvariantCulture),
+            StatusCodes.Status429TooManyRequests.ToString(CultureInfo.InvariantCulture),
+            StatusCodes.Status500InternalServerError.ToString(CultureInfo.InvariantCulture)
+        ];
+
+        public Task TransformAsync(OpenApiDocument doc, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+        {
+            if (doc.Paths is null || doc.Paths.Count == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            AddListExamples(doc);
+            AddMutationExamples(doc);
+
+            return Task.CompletedTask;
+        }
+
+        private static void AddListExamples(OpenApiDocument doc)
+        {
+            if (!doc.Paths.TryGetValue("/friends", out var pathItem))
+            {
+                return;
+            }
+
+            if (!pathItem.Operations.TryGetValue(OperationType.Get, out var operation))
+            {
+                return;
+            }
+
+            if (operation.Responses.TryGetValue(StatusCodes.Status200OK.ToString(CultureInfo.InvariantCulture), out var okResponse))
+            {
+                foreach (var mediaType in okResponse.Content.Values)
+                {
+                    mediaType.Examples ??= new Dictionary<string, OpenApiExample>(StringComparer.Ordinal);
+                    mediaType.Examples["Success"] = BuildFriendListExample();
+                }
+            }
+
+            ApplyProblemExamples(operation);
+        }
+
+        private static void AddMutationExamples(OpenApiDocument doc)
+        {
+            foreach (var path in new[]
+            {
+                "/friends/{userId}/invite",
+                "/friends/{userId}/accept",
+                "/friends/{userId}/decline",
+                "/friends/{userId}/cancel"
+            })
+            {
+                if (!doc.Paths.TryGetValue(path, out var pathItem))
+                {
+                    continue;
+                }
+
+                foreach (var operation in pathItem.Operations.Values)
+                {
+                    ApplyProblemExamples(operation);
+                }
+            }
+        }
+
+        private static void ApplyProblemExamples(OpenApiOperation operation)
+        {
+            foreach (var status in ErrorStatuses)
+            {
+                if (!operation.Responses.TryGetValue(status, out var response))
+                {
+                    continue;
+                }
+
+                foreach (var mediaType in response.Content.Values)
+                {
+                    mediaType.Examples ??= new Dictionary<string, OpenApiExample>(StringComparer.Ordinal);
+                    mediaType.Examples["Error"] = BuildProblemExample(status);
+                }
+            }
+        }
+
+        private static OpenApiExample BuildFriendListExample() => new()
+        {
+            Summary = "Friends list",
+            Value = new OpenApiObject
+            {
+                ["Items"] = new OpenApiArray
+                {
+                    new OpenApiObject
+                    {
+                        ["Id"] = new OpenApiString("11111111-1111-1111-1111-111111111111"),
+                        ["User"] = new OpenApiObject
+                        {
+                            ["Id"] = new OpenApiString("22222222-2222-2222-2222-222222222222"),
+                            ["UserName"] = new OpenApiString("phoenix"),
+                            ["AvatarUrl"] = new OpenApiString("https://cdn.studentgamerhub.dev/avatars/phoenix.png")
+                        },
+                        ["BecameFriendsAtUtc"] = new OpenApiString("2024-05-12T08:15:30Z")
+                    }
+                },
+                ["NextCursor"] = new OpenApiString("YWJjMTIz"),
+                ["PrevCursor"] = OpenApiNull.Instance,
+                ["Size"] = new OpenApiInteger(20),
+                ["Sort"] = new OpenApiString("Id"),
+                ["Desc"] = new OpenApiBoolean(false)
+            }
+        };
+
+        private static OpenApiExample BuildProblemExample(string statusCode)
+        {
+            var status = int.Parse(statusCode, CultureInfo.InvariantCulture);
+            var (title, type) = status switch
+            {
+                StatusCodes.Status400BadRequest => ("validation_error", "https://httpstatuses.com/400"),
+                StatusCodes.Status401Unauthorized => ("unauthorized", "https://httpstatuses.com/401"),
+                StatusCodes.Status403Forbidden => ("forbidden", "https://httpstatuses.com/403"),
+                StatusCodes.Status404NotFound => ("not_found", "https://httpstatuses.com/404"),
+                StatusCodes.Status409Conflict => ("conflict", "https://httpstatuses.com/409"),
+                StatusCodes.Status429TooManyRequests => ("too_many_requests", "https://httpstatuses.com/429"),
+                _ => ("unexpected_error", "https://httpstatuses.com/500")
+            };
+
+            return new OpenApiExample
+            {
+                Summary = $"{status} error",
+                Value = new OpenApiObject
+                {
+                    ["type"] = new OpenApiString(type),
+                    ["title"] = new OpenApiString(title),
+                    ["status"] = new OpenApiInteger(status),
+                    ["detail"] = new OpenApiString("Example error message."),
+                    ["instance"] = new OpenApiString("/friends"),
+                    ["code"] = new OpenApiString(title),
+                    ["traceId"] = new OpenApiString("00-00000000000000000000000000000000-0000000000000000-00")
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- register per-user token bucket rate limiting policies and ensure Scalar/OpenAPI endpoints are mapped
- add a secured FriendsController that surfaces invite/action/list endpoints returning the shared Result pattern
- extend friend mappings/service logic and enrich the OpenAPI document with examples for Result-based responses

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e67a9ee74c832d9aa4228deefdcc57