### PR TITLE
Implement club update and archive workflows

### DIFF
--- a/DTOs/Clubs/ClubCreateRequestDto.cs
+++ b/DTOs/Clubs/ClubCreateRequestDto.cs
@@ -2,9 +2,10 @@ namespace DTOs.Clubs;
 
 /// <summary>
 /// Request DTO for creating a new club.
-/// CommunityId is provided in the route parameter.
+/// Includes the community identifier where the club belongs.
 /// </summary>
 public sealed record ClubCreateRequestDto(
+    Guid CommunityId,
     string Name,
     string? Description,
     bool IsPublic

--- a/DTOs/Clubs/ClubDetailDto.cs
+++ b/DTOs/Clubs/ClubDetailDto.cs
@@ -1,0 +1,13 @@
+namespace DTOs.Clubs;
+
+/// <summary>
+/// Detailed club information.
+/// </summary>
+public sealed record ClubDetailDto(
+    Guid Id,
+    Guid CommunityId,
+    string Name,
+    string? Description,
+    bool IsPublic,
+    int MembersCount
+);

--- a/DTOs/Clubs/ClubUpdateRequestDto.cs
+++ b/DTOs/Clubs/ClubUpdateRequestDto.cs
@@ -1,0 +1,10 @@
+namespace DTOs.Clubs;
+
+/// <summary>
+/// Request DTO for updating club information.
+/// </summary>
+public sealed record ClubUpdateRequestDto(
+    string Name,
+    string? Description,
+    bool IsPublic
+);

--- a/Repositories/Implements/ClubCommandRepository.cs
+++ b/Repositories/Implements/ClubCommandRepository.cs
@@ -23,4 +23,36 @@ public sealed class ClubCommandRepository : IClubCommandRepository
     {
         await _context.Clubs.AddAsync(club, ct);
     }
+
+    /// <summary>
+    /// Update existing club entity.
+    /// </summary>
+    public Task UpdateAsync(Club club, CancellationToken ct = default)
+    {
+        _context.Clubs.Update(club);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Soft delete (archive) a club.
+    /// </summary>
+    public async Task SoftDeleteAsync(Guid clubId, Guid deletedBy, CancellationToken ct = default)
+    {
+        var club = await _context.Clubs
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(c => c.Id == clubId, ct)
+            .ConfigureAwait(false);
+
+        if (club is null)
+            return;
+
+        var now = DateTime.UtcNow;
+        club.IsDeleted = true;
+        club.DeletedAtUtc = now;
+        club.DeletedBy = deletedBy;
+        club.UpdatedAtUtc = now;
+        club.UpdatedBy = deletedBy;
+
+        _context.Clubs.Update(club);
+    }
 }

--- a/Repositories/Implements/ClubQueryRepository.cs
+++ b/Repositories/Implements/ClubQueryRepository.cs
@@ -73,6 +73,19 @@ public sealed class ClubQueryRepository : IClubQueryRepository
     }
 
     /// <summary>
+    /// Check if a club still has approved room members.
+    /// </summary>
+    public async Task<bool> HasAnyApprovedRoomsAsync(Guid clubId, CancellationToken ct = default)
+    {
+        return await _context.RoomMembers
+            .AsNoTracking()
+            .AnyAsync(rm =>
+                rm.Status == RoomMemberStatus.Approved &&
+                rm.Room!.ClubId == clubId,
+                ct);
+    }
+
+    /// <summary>
     /// Get club by ID.
     /// </summary>
     public async Task<Club?> GetByIdAsync(Guid clubId, CancellationToken ct = default)

--- a/Repositories/Interfaces/IClubCommandRepository.cs
+++ b/Repositories/Interfaces/IClubCommandRepository.cs
@@ -13,4 +13,19 @@ public interface IClubCommandRepository
     /// <param name="club">Club entity to create</param>
     /// <param name="ct">Cancellation token</param>
     Task CreateAsync(Club club, CancellationToken ct = default);
+
+    /// <summary>
+    /// Update an existing club.
+    /// </summary>
+    /// <param name="club">Club entity with updated values</param>
+    /// <param name="ct">Cancellation token</param>
+    Task UpdateAsync(Club club, CancellationToken ct = default);
+
+    /// <summary>
+    /// Soft delete (archive) a club.
+    /// </summary>
+    /// <param name="clubId">Club identifier</param>
+    /// <param name="deletedBy">User performing the deletion</param>
+    /// <param name="ct">Cancellation token</param>
+    Task SoftDeleteAsync(Guid clubId, Guid deletedBy, CancellationToken ct = default);
 }

--- a/Repositories/Interfaces/IClubQueryRepository.cs
+++ b/Repositories/Interfaces/IClubQueryRepository.cs
@@ -27,6 +27,13 @@ public interface IClubQueryRepository
         CancellationToken ct = default);
 
     /// <summary>
+    /// Determine whether the club has any approved room members.
+    /// </summary>
+    /// <param name="clubId">Club ID</param>
+    /// <param name="ct">Cancellation token</param>
+    Task<bool> HasAnyApprovedRoomsAsync(Guid clubId, CancellationToken ct = default);
+
+    /// <summary>
     /// Get club by ID.
     /// </summary>
     /// <param name="clubId">Club ID</param>

--- a/Services/Common/Mapping/ClubMappers.cs
+++ b/Services/Common/Mapping/ClubMappers.cs
@@ -21,4 +21,21 @@ public static class ClubMappers
             Description: club.Description
         );
     }
+
+    /// <summary>
+    /// Maps Club entity to ClubDetailDto.
+    /// </summary>
+    public static ClubDetailDto ToClubDetailDto(this Club club)
+    {
+        ArgumentNullException.ThrowIfNull(club);
+
+        return new ClubDetailDto(
+            Id: club.Id,
+            CommunityId: club.CommunityId,
+            Name: club.Name,
+            Description: club.Description,
+            IsPublic: club.IsPublic,
+            MembersCount: club.MembersCount
+        );
+    }
 }

--- a/Services/Interfaces/IClubService.cs
+++ b/Services/Interfaces/IClubService.cs
@@ -53,6 +53,16 @@ public interface IClubService
     /// </summary>
     /// <param name="clubId">Club ID</param>
     /// <param name="ct">Cancellation token</param>
-    /// <returns>Result with club brief DTO, or NotFound if club doesn't exist</returns>
-    Task<Result<ClubBriefDto>> GetByIdAsync(Guid clubId, CancellationToken ct = default);
+    /// <returns>Result with club detail DTO, or NotFound if club doesn't exist</returns>
+    Task<Result<ClubDetailDto>> GetByIdAsync(Guid clubId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Update club information.
+    /// </summary>
+    Task<Result> UpdateAsync(Guid currentUserId, Guid id, ClubUpdateRequestDto req, CancellationToken ct = default);
+
+    /// <summary>
+    /// Archive (soft delete) a club.
+    /// </summary>
+    Task<Result> ArchiveAsync(Guid currentUserId, Guid id, CancellationToken ct = default);
 }

--- a/Tests/Services.Communities.Tests/ClubServiceTests.cs
+++ b/Tests/Services.Communities.Tests/ClubServiceTests.cs
@@ -1,0 +1,186 @@
+using BusinessObjects;
+using BusinessObjects.Common;
+using DTOs.Clubs;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Repositories.Implements;
+using Repositories.Persistence;
+using Repositories.WorkSeeds.Implements;
+using Repositories.WorkSeeds.Interfaces;
+using Services.Implementations;
+using Xunit;
+
+namespace Services.Communities.Tests;
+
+public sealed class ClubServiceTests
+{
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnDetailDto()
+    {
+        await using var ctx = await ClubServiceTestContext.CreateAsync();
+        var community = new Community
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Community",
+            IsPublic = true,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        };
+        var club = new Club
+        {
+            Id = Guid.NewGuid(),
+            CommunityId = community.Id,
+            Name = "Detail Club",
+            Description = "Description",
+            IsPublic = false,
+            MembersCount = 5,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        };
+        ctx.Db.Communities.Add(community);
+        ctx.Db.Clubs.Add(club);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.GetByIdAsync(club.Id);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Id.Should().Be(club.Id);
+        result.Value.Name.Should().Be("Detail Club");
+        result.Value.Description.Should().Be("Description");
+        result.Value.MembersCount.Should().Be(5);
+        result.Value.IsPublic.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldReturnValidationError_WhenNameIsEmpty()
+    {
+        await using var ctx = await ClubServiceTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+        var community = new Community
+        {
+            Id = Guid.NewGuid(),
+            Name = "Community",
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = userId
+        };
+        var club = new Club
+        {
+            Id = Guid.NewGuid(),
+            CommunityId = community.Id,
+            Name = "Club",
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = userId
+        };
+        ctx.Db.Communities.Add(community);
+        ctx.Db.Clubs.Add(club);
+        await ctx.Db.SaveChangesAsync();
+
+        var request = new ClubUpdateRequestDto("  ", "New description", true);
+
+        var result = await ctx.Service.UpdateAsync(userId, club.Id, request);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Validation);
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_ShouldReturnForbidden_WhenApprovedMembersRemain()
+    {
+        await using var ctx = await ClubServiceTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+        var community = new Community
+        {
+            Id = Guid.NewGuid(),
+            Name = "Community",
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = userId
+        };
+        var club = new Club
+        {
+            Id = Guid.NewGuid(),
+            CommunityId = community.Id,
+            Name = "Club",
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = userId
+        };
+        var room = new Room
+        {
+            Id = Guid.NewGuid(),
+            ClubId = club.Id,
+            Name = "Room",
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = userId
+        };
+        var member = new RoomMember
+        {
+            RoomId = room.Id,
+            UserId = Guid.NewGuid(),
+            Status = RoomMemberStatus.Approved,
+            Role = RoomRole.Member,
+            JoinedAt = DateTimeOffset.UtcNow,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = userId
+        };
+        ctx.Db.Communities.Add(community);
+        ctx.Db.Clubs.Add(club);
+        ctx.Db.Rooms.Add(room);
+        ctx.Db.RoomMembers.Add(member);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.ArchiveAsync(userId, club.Id);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Forbidden);
+    }
+
+    private sealed class ClubServiceTestContext : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly IGenericUnitOfWork _uow;
+
+        public required AppDbContext Db { get; init; }
+        public required ClubService Service { get; init; }
+
+        private ClubServiceTestContext(SqliteConnection connection, IGenericUnitOfWork uow)
+        {
+            _connection = connection;
+            _uow = uow;
+        }
+
+        public static async Task<ClubServiceTestContext> CreateAsync()
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var db = new AppDbContext(options);
+            await db.Database.EnsureCreatedAsync();
+
+            var services = new ServiceCollection().BuildServiceProvider();
+            var factory = new RepositoryFactory(db, services);
+            var uow = new UnitOfWork(db, factory);
+            var queryRepo = new ClubQueryRepository(db);
+            var commandRepo = new ClubCommandRepository(db);
+            var service = new ClubService(uow, queryRepo, commandRepo);
+
+            return new ClubServiceTestContext(connection, uow)
+            {
+                Db = db,
+                Service = service
+            };
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _uow.DisposeAsync();
+            await Db.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+}

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -167,8 +167,8 @@ public static class ServiceCollectionExtensions
                 });
             });
 
-            // Clubs create rate limiting: 10 requests per day per user
-            options.AddPolicy("ClubsCreate", httpContext =>
+            // Clubs write rate limiting (create/update/archive): 10 requests per day per user
+            options.AddPolicy("ClubsWrite", httpContext =>
             {
                 var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
 
@@ -182,6 +182,7 @@ public static class ServiceCollectionExtensions
                     AutoReplenishment = true
                 });
             });
+
         });
 
         services.TryAddSingleton<IConnectionMultiplexer>(sp =>


### PR DESCRIPTION
## Summary
- add detailed/update DTOs and mapping for clubs
- extend club repositories and service to support update, archive, and approved-room checks with authorization
- expose PATCH/DELETE endpoints with unified rate limiting and add unit tests for validation and archive rules

## Testing
- dotnet test StudentGamerHub.sln *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8d4293544832da1dc84739c7c7f46