### PR TITLE
Implement room management enhancements

### DIFF
--- a/DTOs/Rooms/RoomDetailDto.cs
+++ b/DTOs/Rooms/RoomDetailDto.cs
@@ -1,0 +1,14 @@
+namespace DTOs.Rooms;
+
+/// <summary>
+/// Detailed information about a room.
+/// </summary>
+public sealed record RoomDetailDto(
+    Guid Id,
+    Guid ClubId,
+    string Name,
+    string? Description,
+    RoomJoinPolicy JoinPolicy,
+    int? Capacity,
+    int MembersCount
+);

--- a/DTOs/Rooms/RoomMemberBriefDto.cs
+++ b/DTOs/Rooms/RoomMemberBriefDto.cs
@@ -1,0 +1,12 @@
+namespace DTOs.Rooms;
+
+/// <summary>
+/// Brief information about a room member.
+/// </summary>
+public sealed record RoomMemberBriefDto(
+    Guid UserId,
+    string FullName,
+    RoomRole Role,
+    RoomMemberStatus Status,
+    DateTimeOffset JoinedAt
+);

--- a/DTOs/Rooms/RoomUpdateRequestDto.cs
+++ b/DTOs/Rooms/RoomUpdateRequestDto.cs
@@ -1,0 +1,12 @@
+namespace DTOs.Rooms;
+
+/// <summary>
+/// Request DTO for updating a room.
+/// </summary>
+public sealed record RoomUpdateRequestDto(
+    string Name,
+    string? Description,
+    RoomJoinPolicy JoinPolicy,
+    string? Password,
+    int? Capacity
+);

--- a/Repositories/Interfaces/IRoomCommandRepository.cs
+++ b/Repositories/Interfaces/IRoomCommandRepository.cs
@@ -12,6 +12,16 @@ public interface IRoomCommandRepository
     Task CreateRoomAsync(Room room, CancellationToken ct = default);
 
     /// <summary>
+    /// Update existing room information.
+    /// </summary>
+    Task UpdateRoomAsync(Room room, CancellationToken ct = default);
+
+    /// <summary>
+    /// Soft delete a room by ID.
+    /// </summary>
+    Task SoftDeleteRoomAsync(Guid roomId, Guid deletedBy, CancellationToken ct = default);
+
+    /// <summary>
     /// Upsert room member (insert or update if exists).
     /// </summary>
     Task UpsertMemberAsync(RoomMember member, CancellationToken ct = default);

--- a/Repositories/Interfaces/IRoomQueryRepository.cs
+++ b/Repositories/Interfaces/IRoomQueryRepository.cs
@@ -12,6 +12,11 @@ public interface IRoomQueryRepository
     Task<Room?> GetRoomWithClubCommunityAsync(Guid roomId, CancellationToken ct = default);
 
     /// <summary>
+    /// Get a room by ID with Club and Community navigations tracked for updates.
+    /// </summary>
+    Task<Room?> GetByIdAsync(Guid roomId, CancellationToken ct = default);
+
+    /// <summary>
     /// Get specific room member record.
     /// </summary>
     Task<RoomMember?> GetMemberAsync(Guid roomId, Guid userId, CancellationToken ct = default);
@@ -20,6 +25,11 @@ public interface IRoomQueryRepository
     /// Count approved members in a room (Status == Approved).
     /// </summary>
     Task<int> CountApprovedMembersAsync(Guid roomId, CancellationToken ct = default);
+
+    /// <summary>
+    /// List room members with pagination support.
+    /// </summary>
+    Task<IReadOnlyList<RoomMember>> ListMembersAsync(Guid roomId, int take, int skip, CancellationToken ct = default);
 
     /// <summary>
     /// Check if user has any approved membership in any room of this club.

--- a/Services/Common/Mapping/RoomMappers.cs
+++ b/Services/Common/Mapping/RoomMappers.cs
@@ -1,0 +1,39 @@
+namespace Services.Common.Mapping;
+
+/// <summary>
+/// Mapping helpers for room entities and DTOs.
+/// </summary>
+public static class RoomMappers
+{
+    /// <summary>
+    /// Maps <see cref="Room"/> to <see cref="RoomDetailDto"/>.
+    /// </summary>
+    public static RoomDetailDto ToRoomDetailDto(this Room room)
+    {
+        ArgumentNullException.ThrowIfNull(room);
+
+        return new RoomDetailDto(
+            room.Id,
+            room.ClubId,
+            room.Name,
+            room.Description,
+            room.JoinPolicy,
+            room.Capacity,
+            room.MembersCount);
+    }
+
+    /// <summary>
+    /// Maps <see cref="RoomMember"/> to <see cref="RoomMemberBriefDto"/>.
+    /// </summary>
+    public static RoomMemberBriefDto ToRoomMemberBriefDto(this RoomMember member)
+    {
+        ArgumentNullException.ThrowIfNull(member);
+
+        return new RoomMemberBriefDto(
+            member.UserId,
+            member.User?.FullName ?? string.Empty,
+            member.Role,
+            member.Status,
+            member.JoinedAt);
+    }
+}

--- a/Services/Interfaces/IRoomService.cs
+++ b/Services/Interfaces/IRoomService.cs
@@ -87,9 +87,34 @@ public interface IRoomService
     /// <param name="ct">Cancellation token</param>
     /// <returns>Success or error</returns>
     Task<Result> KickOrBanAsync(
-        Guid currentUserId, 
-        Guid roomId, 
-        Guid targetUserId, 
-        bool ban, 
+        Guid currentUserId,
+        Guid roomId,
+        Guid targetUserId,
+        bool ban,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Get room detail by ID.
+    /// </summary>
+    Task<Result<RoomDetailDto>> GetByIdAsync(Guid roomId, CancellationToken ct = default);
+
+    /// <summary>
+    /// List room members with pagination.
+    /// </summary>
+    Task<Result<IReadOnlyList<RoomMemberBriefDto>>> ListMembersAsync(Guid roomId, int skip, int take, CancellationToken ct = default);
+
+    /// <summary>
+    /// Update room metadata. Only owner can update.
+    /// </summary>
+    Task<Result> UpdateRoomAsync(Guid currentUserId, Guid roomId, RoomUpdateRequestDto req, CancellationToken ct = default);
+
+    /// <summary>
+    /// Transfer ownership to another approved member.
+    /// </summary>
+    Task<Result> TransferOwnershipAsync(Guid currentUserId, Guid roomId, Guid newOwnerUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Archive a room (soft delete). Only allowed when no other approved members remain.
+    /// </summary>
+    Task<Result> ArchiveRoomAsync(Guid currentUserId, Guid roomId, CancellationToken ct = default);
 }

--- a/StudentGamerHub.sln
+++ b/StudentGamerHub.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI", "WebAPI\WebAPI.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services.Communities.Tests", "Tests\Services.Communities.Tests\Services.Communities.Tests.csproj", "{AFFA98D0-CB06-4169-B240-C1D6EC11D067}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services.Rooms.Tests", "Tests\Services.Rooms.Tests\Services.Rooms.Tests.csproj", "{681A03FB-C9F6-4AFB-8761-5BDB5F57CDD5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
                 {AFFA98D0-CB06-4169-B240-C1D6EC11D067}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {AFFA98D0-CB06-4169-B240-C1D6EC11D067}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {AFFA98D0-CB06-4169-B240-C1D6EC11D067}.Release|Any CPU.Build.0 = Release|Any CPU
+                {681A03FB-C9F6-4AFB-8761-5BDB5F57CDD5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {681A03FB-C9F6-4AFB-8761-5BDB5F57CDD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {681A03FB-C9F6-4AFB-8761-5BDB5F57CDD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {681A03FB-C9F6-4AFB-8761-5BDB5F57CDD5}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/Services.Rooms.Tests/RoomServiceTests.cs
+++ b/Tests/Services.Rooms.Tests/RoomServiceTests.cs
@@ -1,0 +1,216 @@
+using BusinessObjects;
+using BusinessObjects.Common;
+using BusinessObjects.Common.Results;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Repositories.Implements;
+using Repositories.Persistence;
+using Repositories.WorkSeeds.Implements;
+using Repositories.WorkSeeds.Interfaces;
+using Services.Implementations;
+using Xunit;
+
+namespace Services.Rooms.Tests;
+
+public sealed class RoomServiceTests
+{
+    [Fact]
+    public async Task UpdateRoomAsync_ShouldRequirePassword_WhenPolicyRequiresPassword()
+    {
+        await using var ctx = await RoomServiceTestContext.CreateAsync();
+        var ownerId = Guid.NewGuid();
+
+        var community = SeedCommunity(ctx, ownerId);
+        var club = SeedClub(ctx, community.Id, ownerId);
+        var room = SeedRoom(ctx, club.Id, ownerId, RoomJoinPolicy.Open, membersCount: 1);
+        SeedMember(ctx, room.Id, ownerId, RoomRole.Owner, RoomMemberStatus.Approved);
+        await ctx.Db.SaveChangesAsync();
+
+        var request = new RoomUpdateRequestDto("Updated", null, RoomJoinPolicy.RequiresPassword, null, null);
+
+        var result = await ctx.Service.UpdateRoomAsync(ownerId, room.Id, request);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Validation);
+    }
+
+    [Fact]
+    public async Task UpdateRoomAsync_ShouldReturnConflict_WhenCapacityLowerThanApproved()
+    {
+        await using var ctx = await RoomServiceTestContext.CreateAsync();
+        var ownerId = Guid.NewGuid();
+        var memberId = Guid.NewGuid();
+
+        var community = SeedCommunity(ctx, ownerId);
+        var club = SeedClub(ctx, community.Id, ownerId);
+        var room = SeedRoom(ctx, club.Id, ownerId, RoomJoinPolicy.Open, membersCount: 2);
+        SeedMember(ctx, room.Id, ownerId, RoomRole.Owner, RoomMemberStatus.Approved);
+        SeedMember(ctx, room.Id, memberId, RoomRole.Member, RoomMemberStatus.Approved);
+        await ctx.Db.SaveChangesAsync();
+
+        var request = new RoomUpdateRequestDto("Updated", "Desc", RoomJoinPolicy.Open, null, 1);
+
+        var result = await ctx.Service.UpdateRoomAsync(ownerId, room.Id, request);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Conflict);
+    }
+
+    [Fact]
+    public async Task TransferOwnershipAsync_ShouldSwapRolesBetweenOwnerAndTarget()
+    {
+        await using var ctx = await RoomServiceTestContext.CreateAsync();
+        var ownerId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        var community = SeedCommunity(ctx, ownerId);
+        var club = SeedClub(ctx, community.Id, ownerId);
+        var room = SeedRoom(ctx, club.Id, ownerId, RoomJoinPolicy.Open, membersCount: 2);
+        SeedMember(ctx, room.Id, ownerId, RoomRole.Owner, RoomMemberStatus.Approved);
+        SeedMember(ctx, room.Id, targetId, RoomRole.Member, RoomMemberStatus.Approved);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.TransferOwnershipAsync(ownerId, room.Id, targetId);
+
+        result.IsSuccess.Should().BeTrue();
+
+        var members = await ctx.Db.RoomMembers
+            .Where(m => m.RoomId == room.Id)
+            .ToDictionaryAsync(m => m.UserId);
+
+        members[ownerId].Role.Should().Be(RoomRole.Moderator);
+        members[targetId].Role.Should().Be(RoomRole.Owner);
+    }
+
+    [Fact]
+    public async Task ArchiveRoomAsync_ShouldReturnForbidden_WhenApprovedMembersRemain()
+    {
+        await using var ctx = await RoomServiceTestContext.CreateAsync();
+        var ownerId = Guid.NewGuid();
+        var memberId = Guid.NewGuid();
+
+        var community = SeedCommunity(ctx, ownerId);
+        var club = SeedClub(ctx, community.Id, ownerId);
+        var room = SeedRoom(ctx, club.Id, ownerId, RoomJoinPolicy.Open, membersCount: 2);
+        SeedMember(ctx, room.Id, ownerId, RoomRole.Owner, RoomMemberStatus.Approved);
+        SeedMember(ctx, room.Id, memberId, RoomRole.Member, RoomMemberStatus.Approved);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.ArchiveRoomAsync(ownerId, room.Id);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Forbidden);
+    }
+
+    private static Community SeedCommunity(RoomServiceTestContext ctx, Guid createdBy)
+    {
+        var community = new Community
+        {
+            Id = Guid.NewGuid(),
+            Name = "Community",
+            IsPublic = true,
+            MembersCount = 0,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = createdBy
+        };
+        ctx.Db.Communities.Add(community);
+        return community;
+    }
+
+    private static Club SeedClub(RoomServiceTestContext ctx, Guid communityId, Guid createdBy)
+    {
+        var club = new Club
+        {
+            Id = Guid.NewGuid(),
+            CommunityId = communityId,
+            Name = "Club",
+            IsPublic = true,
+            MembersCount = 0,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = createdBy
+        };
+        ctx.Db.Clubs.Add(club);
+        return club;
+    }
+
+    private static Room SeedRoom(RoomServiceTestContext ctx, Guid clubId, Guid createdBy, RoomJoinPolicy policy, int membersCount)
+    {
+        var room = new Room
+        {
+            Id = Guid.NewGuid(),
+            ClubId = clubId,
+            Name = "Room",
+            JoinPolicy = policy,
+            MembersCount = membersCount,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = createdBy
+        };
+        ctx.Db.Rooms.Add(room);
+        return room;
+    }
+
+    private static void SeedMember(RoomServiceTestContext ctx, Guid roomId, Guid userId, RoomRole role, RoomMemberStatus status)
+    {
+        var member = new RoomMember
+        {
+            RoomId = roomId,
+            UserId = userId,
+            Role = role,
+            Status = status,
+            JoinedAt = DateTimeOffset.UtcNow
+        };
+        ctx.Db.RoomMembers.Add(member);
+    }
+
+    private sealed class RoomServiceTestContext : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly IGenericUnitOfWork _uow;
+
+        public required AppDbContext Db { get; init; }
+        public required RoomService Service { get; init; }
+
+        private RoomServiceTestContext(SqliteConnection connection, IGenericUnitOfWork uow)
+        {
+            _connection = connection;
+            _uow = uow;
+        }
+
+        public static async Task<RoomServiceTestContext> CreateAsync()
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var db = new AppDbContext(options);
+            await db.Database.EnsureCreatedAsync();
+
+            var services = new ServiceCollection().BuildServiceProvider();
+            var factory = new RepositoryFactory(db, services);
+            var uow = new UnitOfWork(db, factory);
+            var queryRepo = new RoomQueryRepository(db);
+            var commandRepo = new RoomCommandRepository(db);
+            var passwordHasher = new PasswordHasher<Room>();
+            var service = new RoomService(uow, queryRepo, commandRepo, passwordHasher);
+
+            return new RoomServiceTestContext(connection, uow)
+            {
+                Db = db,
+                Service = service
+            };
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _uow.DisposeAsync();
+            await Db.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+}

--- a/Tests/Services.Rooms.Tests/Services.Rooms.Tests.csproj
+++ b/Tests/Services.Rooms.Tests/Services.Rooms.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Services\Services.csproj" />
+  </ItemGroup>
+</Project>

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -103,16 +103,48 @@ public static class ServiceCollectionExtensions
                 });
             });
 
-            // Room actions rate limiting: 60 requests per minute per user
-            options.AddPolicy("RoomsAction", httpContext =>
+            // Room read rate limiting: 120 requests per minute per user
+            options.AddPolicy("RoomsRead", httpContext =>
             {
                 var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
 
                 return RateLimitPartition.GetTokenBucketLimiter(userKey, _ => new TokenBucketRateLimiterOptions
                 {
-                    TokenLimit = 60,
-                    TokensPerPeriod = 60,
+                    TokenLimit = 120,
+                    TokensPerPeriod = 120,
                     ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                });
+            });
+
+            // Room write rate limiting: 30 requests per minute per user
+            options.AddPolicy("RoomsWrite", httpContext =>
+            {
+                var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
+
+                return RateLimitPartition.GetTokenBucketLimiter(userKey, _ => new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = 30,
+                    TokensPerPeriod = 30,
+                    ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                });
+            });
+
+            // Room archive rate limiting: 10 requests per day per user
+            options.AddPolicy("RoomsArchive", httpContext =>
+            {
+                var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
+
+                return RateLimitPartition.GetTokenBucketLimiter(userKey, _ => new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = 10,
+                    TokensPerPeriod = 10,
+                    ReplenishmentPeriod = TimeSpan.FromDays(1),
                     QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                     QueueLimit = 0,
                     AutoReplenishment = true


### PR DESCRIPTION
## Summary
- add DTOs and mapping helpers for room details and member summaries
- extend room repositories and service logic to support read, update, transfer ownership, and archive flows with appropriate validations and counter updates
- expose new API endpoints with rate limits and add room service regression tests for validation, capacity, ownership transfer, and archive guards

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e8e1695b88832da5e153e9d9dc800e