### PR TITLE
Implement event and payment infrastructure repositories

### DIFF
--- a/Repositories/DependencyInjection/InfrastructureRegistration.cs
+++ b/Repositories/DependencyInjection/InfrastructureRegistration.cs
@@ -68,6 +68,14 @@ namespace Repositories.DependencyInjection
             services.AddScoped<IRoomCommandRepository, RoomCommandRepository>();
             services.AddScoped<IClubQueryRepository, ClubQueryRepository>();
             services.AddScoped<IClubCommandRepository, ClubCommandRepository>();
+            services.AddScoped<IEventQueryRepository, EventQueryRepository>();
+            services.AddScoped<IEventCommandRepository, EventCommandRepository>();
+            services.AddScoped<IRegistrationQueryRepository, RegistrationQueryRepository>();
+            services.AddScoped<IRegistrationCommandRepository, RegistrationCommandRepository>();
+            services.AddScoped<IEscrowRepository, EscrowRepository>();
+            services.AddScoped<IWalletRepository, WalletRepository>();
+            services.AddScoped<ITransactionRepository, TransactionRepository>();
+            services.AddScoped<IPaymentIntentRepository, PaymentIntentRepository>();
 
             // 6) Hosted seeding
             services.AddHostedService<DbInitializerHostedService>();

--- a/Repositories/Implements/EscrowRepository.cs
+++ b/Repositories/Implements/EscrowRepository.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Repositories.Implements;
+
+public sealed class EscrowRepository : IEscrowRepository
+{
+    private readonly AppDbContext _context;
+
+    public EscrowRepository(AppDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public Task<Escrow?> GetByEventIdAsync(Guid eventId, CancellationToken ct = default)
+        => _context.Escrows
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.EventId == eventId, ct);
+
+    public async Task UpsertAsync(Escrow escrow, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(escrow);
+
+        var existing = await _context.Escrows
+            .FirstOrDefaultAsync(e => e.EventId == escrow.EventId, ct)
+            .ConfigureAwait(false);
+
+        if (existing is null)
+        {
+            await _context.Escrows.AddAsync(escrow, ct).ConfigureAwait(false);
+            return;
+        }
+
+        existing.AmountHoldCents = escrow.AmountHoldCents;
+        existing.Status = escrow.Status;
+
+        _context.Escrows.Update(existing);
+    }
+}

--- a/Repositories/Implements/EventCommandRepository.cs
+++ b/Repositories/Implements/EventCommandRepository.cs
@@ -1,0 +1,24 @@
+namespace Repositories.Implements;
+
+public sealed class EventCommandRepository : IEventCommandRepository
+{
+    private readonly AppDbContext _context;
+
+    public EventCommandRepository(AppDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task CreateAsync(Event e, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(e);
+        await _context.Events.AddAsync(e, ct).ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(Event e, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(e);
+        _context.Events.Update(e);
+        return Task.CompletedTask;
+    }
+}

--- a/Repositories/Implements/PaymentIntentRepository.cs
+++ b/Repositories/Implements/PaymentIntentRepository.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Repositories.Implements;
+
+public sealed class PaymentIntentRepository : IPaymentIntentRepository
+{
+    private readonly AppDbContext _context;
+
+    public PaymentIntentRepository(AppDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public Task<PaymentIntent?> GetByIdAsync(Guid id, CancellationToken ct = default)
+        => _context.PaymentIntents
+            .AsNoTracking()
+            .FirstOrDefaultAsync(pi => pi.Id == id, ct);
+
+    public Task<PaymentIntent?> GetByIdForUserAsync(Guid id, Guid userId, CancellationToken ct = default)
+        => _context.PaymentIntents
+            .Where(pi => pi.UserId == userId && pi.Id == id)
+            .Include(pi => pi.EventRegistration)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(ct);
+
+    public async Task CreateAsync(PaymentIntent pi, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(pi);
+        await _context.PaymentIntents.AddAsync(pi, ct).ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(PaymentIntent pi, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(pi);
+        _context.PaymentIntents.Update(pi);
+        return Task.CompletedTask;
+    }
+}

--- a/Repositories/Implements/RegistrationCommandRepository.cs
+++ b/Repositories/Implements/RegistrationCommandRepository.cs
@@ -1,0 +1,24 @@
+namespace Repositories.Implements;
+
+public sealed class RegistrationCommandRepository : IRegistrationCommandRepository
+{
+    private readonly AppDbContext _context;
+
+    public RegistrationCommandRepository(AppDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task CreateAsync(EventRegistration r, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(r);
+        await _context.EventRegistrations.AddAsync(r, ct).ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(EventRegistration r, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(r);
+        _context.EventRegistrations.Update(r);
+        return Task.CompletedTask;
+    }
+}

--- a/Repositories/Implements/RegistrationQueryRepository.cs
+++ b/Repositories/Implements/RegistrationQueryRepository.cs
@@ -1,0 +1,115 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Repositories.Implements;
+
+public sealed class RegistrationQueryRepository : IRegistrationQueryRepository
+{
+    private readonly AppDbContext _context;
+
+    public RegistrationQueryRepository(AppDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public Task<EventRegistration?> GetByEventAndUserAsync(Guid eventId, Guid userId, CancellationToken ct = default)
+        => _context.EventRegistrations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.EventId == eventId && r.UserId == userId, ct);
+
+    public Task<EventRegistration?> GetByIdAsync(Guid id, CancellationToken ct = default)
+        => _context.EventRegistrations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == id, ct);
+
+    public async Task<(IReadOnlyList<EventRegistration> Items, int Total)> ListByEventAsync(
+        Guid eventId,
+        IEnumerable<EventRegistrationStatus>? statuses,
+        int page,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        var query = _context.EventRegistrations
+            .AsNoTracking()
+            .Where(r => r.EventId == eventId);
+
+        if (statuses is not null)
+        {
+            var allowed = statuses.Distinct().ToArray();
+            if (allowed.Length > 0)
+            {
+                query = query.Where(r => allowed.Contains(r.Status));
+            }
+        }
+
+        var total = await query.CountAsync(ct).ConfigureAwait(false);
+
+        if (pageSize <= 0)
+        {
+            pageSize = 20;
+        }
+
+        if (page <= 0)
+        {
+            page = 1;
+        }
+
+        var skip = (page - 1) * pageSize;
+
+        var items = await query
+            .OrderByDescending(r => r.RegisteredAt)
+            .ThenByDescending(r => r.Id)
+            .Skip(skip)
+            .Take(pageSize)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        return (items, total);
+    }
+
+    public async Task<(IReadOnlyList<(EventRegistration Reg, Event Ev)> Items, int Total)> ListByUserAsync(
+        Guid userId,
+        IEnumerable<EventRegistrationStatus>? statuses,
+        int page,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        var query = _context.EventRegistrations
+            .Where(r => r.UserId == userId)
+            .Include(r => r.Event)
+            .AsNoTracking();
+
+        if (statuses is not null)
+        {
+            var allowed = statuses.Distinct().ToArray();
+            if (allowed.Length > 0)
+            {
+                query = query.Where(r => allowed.Contains(r.Status));
+            }
+        }
+
+        var total = await query.CountAsync(ct).ConfigureAwait(false);
+
+        if (pageSize <= 0)
+        {
+            pageSize = 20;
+        }
+
+        if (page <= 0)
+        {
+            page = 1;
+        }
+
+        var skip = (page - 1) * pageSize;
+
+        var items = await query
+            .OrderByDescending(r => r.RegisteredAt)
+            .ThenByDescending(r => r.Id)
+            .Skip(skip)
+            .Take(pageSize)
+            .Select(r => new { Registration = r, Event = r.Event! })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        return (items.Select(x => ((EventRegistration Reg, Event Ev))(x.Registration, x.Event)).ToList(), total);
+    }
+}

--- a/Repositories/Implements/TransactionRepository.cs
+++ b/Repositories/Implements/TransactionRepository.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Repositories.Implements;
+
+public sealed class TransactionRepository : ITransactionRepository
+{
+    private readonly AppDbContext _context;
+
+    public TransactionRepository(AppDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task CreateAsync(Transaction tx, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(tx);
+        await _context.Transactions.AddAsync(tx, ct).ConfigureAwait(false);
+    }
+
+    public Task<bool> ExistsByProviderRefAsync(string provider, string providerRef, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerRef);
+
+        var normalizedProvider = provider.Trim();
+        var normalizedRef = providerRef.Trim();
+
+        return _context.Transactions
+            .AsNoTracking()
+            .AnyAsync(t => t.Provider == normalizedProvider && t.ProviderRef == normalizedRef, ct);
+    }
+}

--- a/Repositories/Implements/WalletRepository.cs
+++ b/Repositories/Implements/WalletRepository.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Repositories.Implements;
+
+public sealed class WalletRepository : IWalletRepository
+{
+    private readonly AppDbContext _context;
+
+    public WalletRepository(AppDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public Task<Wallet?> GetByUserIdAsync(Guid userId, CancellationToken ct = default)
+        => _context.Wallets
+            .AsNoTracking()
+            .FirstOrDefaultAsync(w => w.UserId == userId, ct);
+
+    public async Task CreateIfMissingAsync(Guid userId, CancellationToken ct = default)
+    {
+        var exists = await _context.Wallets
+            .AsNoTracking()
+            .AnyAsync(w => w.UserId == userId, ct)
+            .ConfigureAwait(false);
+
+        if (exists)
+        {
+            return;
+        }
+
+        var wallet = new Wallet
+        {
+            UserId = userId,
+        };
+
+        await _context.Wallets.AddAsync(wallet, ct).ConfigureAwait(false);
+    }
+
+    public async Task<bool> AdjustBalanceAsync(Guid userId, long deltaCents, CancellationToken ct = default)
+    {
+        if (deltaCents == 0)
+        {
+            return true;
+        }
+
+        var query = _context.Wallets.Where(w => w.UserId == userId);
+
+        if (deltaCents < 0)
+        {
+            query = query.Where(w => w.BalanceCents + deltaCents >= 0);
+        }
+
+        var affected = await query.ExecuteUpdateAsync(setters =>
+            setters.SetProperty(w => w.BalanceCents, w => w.BalanceCents + deltaCents), ct).ConfigureAwait(false);
+
+        return affected > 0;
+    }
+}

--- a/Repositories/Interfaces/IEscrowRepository.cs
+++ b/Repositories/Interfaces/IEscrowRepository.cs
@@ -1,0 +1,7 @@
+namespace Repositories.Interfaces;
+
+public interface IEscrowRepository
+{
+    Task<Escrow?> GetByEventIdAsync(Guid eventId, CancellationToken ct = default);
+    Task UpsertAsync(Escrow escrow, CancellationToken ct = default);
+}

--- a/Repositories/Interfaces/IEventCommandRepository.cs
+++ b/Repositories/Interfaces/IEventCommandRepository.cs
@@ -1,0 +1,7 @@
+namespace Repositories.Interfaces;
+
+public interface IEventCommandRepository
+{
+    Task CreateAsync(Event e, CancellationToken ct = default);
+    Task UpdateAsync(Event e, CancellationToken ct = default);
+}

--- a/Repositories/Interfaces/IEventQueryRepository.cs
+++ b/Repositories/Interfaces/IEventQueryRepository.cs
@@ -1,17 +1,20 @@
 namespace Repositories.Interfaces;
 
-/// <summary>
-/// Query interface for Event entity - Dashboard feature
-/// </summary>
 public interface IEventQueryRepository
 {
-    /// <summary>
-    /// Get events starting within UTC range [startUtc, endUtc)
-    /// Filters: Status != Draft/Canceled, soft-delete enabled
-    /// Uses StartsAt index
-    /// </summary>
-    Task<IReadOnlyList<Event>> GetEventsStartingInRangeUtcAsync(
-        DateTimeOffset startUtc, 
-        DateTimeOffset endUtc, 
+    Task<Event?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<Event?> GetForUpdateAsync(Guid id, CancellationToken ct = default);
+    Task<int> CountConfirmedAsync(Guid eventId, CancellationToken ct = default);
+    Task<int> CountPendingOrConfirmedAsync(Guid eventId, CancellationToken ct = default);
+    Task<(IReadOnlyList<Event> Items, int Total)> SearchAsync(
+        IEnumerable<EventStatus>? statuses,
+        Guid? communityId,
+        Guid? organizerId,
+        DateTimeOffset? from,
+        DateTimeOffset? to,
+        string? search,
+        int page,
+        int pageSize,
+        bool sortAscByStartsAt,
         CancellationToken ct = default);
 }

--- a/Repositories/Interfaces/IPaymentIntentRepository.cs
+++ b/Repositories/Interfaces/IPaymentIntentRepository.cs
@@ -1,0 +1,9 @@
+namespace Repositories.Interfaces;
+
+public interface IPaymentIntentRepository
+{
+    Task<PaymentIntent?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<PaymentIntent?> GetByIdForUserAsync(Guid id, Guid userId, CancellationToken ct = default);
+    Task CreateAsync(PaymentIntent pi, CancellationToken ct = default);
+    Task UpdateAsync(PaymentIntent pi, CancellationToken ct = default);
+}

--- a/Repositories/Interfaces/IRegistrationCommandRepository.cs
+++ b/Repositories/Interfaces/IRegistrationCommandRepository.cs
@@ -1,0 +1,7 @@
+namespace Repositories.Interfaces;
+
+public interface IRegistrationCommandRepository
+{
+    Task CreateAsync(EventRegistration r, CancellationToken ct = default);
+    Task UpdateAsync(EventRegistration r, CancellationToken ct = default);
+}

--- a/Repositories/Interfaces/IRegistrationQueryRepository.cs
+++ b/Repositories/Interfaces/IRegistrationQueryRepository.cs
@@ -1,0 +1,19 @@
+namespace Repositories.Interfaces;
+
+public interface IRegistrationQueryRepository
+{
+    Task<EventRegistration?> GetByEventAndUserAsync(Guid eventId, Guid userId, CancellationToken ct = default);
+    Task<EventRegistration?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<(IReadOnlyList<EventRegistration> Items, int Total)> ListByEventAsync(
+        Guid eventId,
+        IEnumerable<EventRegistrationStatus>? statuses,
+        int page,
+        int pageSize,
+        CancellationToken ct = default);
+    Task<(IReadOnlyList<(EventRegistration Reg, Event Ev)> Items, int Total)> ListByUserAsync(
+        Guid userId,
+        IEnumerable<EventRegistrationStatus>? statuses,
+        int page,
+        int pageSize,
+        CancellationToken ct = default);
+}

--- a/Repositories/Interfaces/ITransactionRepository.cs
+++ b/Repositories/Interfaces/ITransactionRepository.cs
@@ -1,0 +1,7 @@
+namespace Repositories.Interfaces;
+
+public interface ITransactionRepository
+{
+    Task CreateAsync(Transaction tx, CancellationToken ct = default);
+    Task<bool> ExistsByProviderRefAsync(string provider, string providerRef, CancellationToken ct = default);
+}

--- a/Repositories/Interfaces/IWalletRepository.cs
+++ b/Repositories/Interfaces/IWalletRepository.cs
@@ -1,0 +1,8 @@
+namespace Repositories.Interfaces;
+
+public interface IWalletRepository
+{
+    Task<Wallet?> GetByUserIdAsync(Guid userId, CancellationToken ct = default);
+    Task CreateIfMissingAsync(Guid userId, CancellationToken ct = default);
+    Task<bool> AdjustBalanceAsync(Guid userId, long deltaCents, CancellationToken ct = default);
+}


### PR DESCRIPTION
## Summary
- replace the event query interface and implementation to support detailed lookups, counts, and paged search filters
- add command/query repositories for events, registrations, escrows, wallets, transactions, and payment intents with the required EF Core behaviors
- register the new repositories in the infrastructure DI configuration

## Testing
- dotnet build *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec522bc490832db2941e6ee1af8efa