### PR TITLE
Add event APIs with rate limiting and tests

### DIFF
--- a/Repositories/Implements/EventQueryRepository.cs
+++ b/Repositories/Implements/EventQueryRepository.cs
@@ -15,12 +15,12 @@ public sealed class EventQueryRepository : IEventQueryRepository
     public Task<Event?> GetByIdAsync(Guid id, CancellationToken ct = default)
         => _context.Events
             .AsNoTracking()
-            .FirstOrDefaultAsync(e => e.Id == id, ct);
+            .FirstOrDefaultAsync(e => e.Id == id && !e.IsDeleted, ct);
 
     public async Task<Event?> GetForUpdateAsync(Guid id, CancellationToken ct = default)
     {
         var query = _context.Events
-            .Where(e => e.Id == id);
+            .Where(e => e.Id == id && !e.IsDeleted);
 
         if (_context.Database.IsNpgsql())
         {
@@ -62,7 +62,10 @@ public sealed class EventQueryRepository : IEventQueryRepository
         bool sortAscByStartsAt,
         CancellationToken ct = default)
     {
-        var query = _context.Events.AsNoTracking().AsQueryable();
+        var query = _context.Events
+            .AsNoTracking()
+            .Where(e => !e.IsDeleted)
+            .AsQueryable();
 
         if (statuses is not null)
         {

--- a/Services/Implementations/EventReadService.cs
+++ b/Services/Implementations/EventReadService.cs
@@ -71,6 +71,7 @@ public sealed class EventReadService : IEventReadService
     public async Task<Result<PagedResponse<EventDetailDto>>> SearchMyOrganizedAsync(
         Guid organizerId,
         IEnumerable<EventStatus>? statuses,
+        Guid? communityId,
         DateTimeOffset? from,
         DateTimeOffset? to,
         string? search,
@@ -81,7 +82,7 @@ public sealed class EventReadService : IEventReadService
     {
         var (items, total) = await _eventQueryRepository.SearchAsync(
             statuses,
-            communityId: null,
+            communityId,
             organizerId: organizerId,
             from,
             to,

--- a/Services/Interfaces/IEventReadService.cs
+++ b/Services/Interfaces/IEventReadService.cs
@@ -18,6 +18,7 @@ public interface IEventReadService
     Task<Result<PagedResponse<EventDetailDto>>> SearchMyOrganizedAsync(
         Guid organizerId,
         IEnumerable<EventStatus>? statuses,
+        Guid? communityId,
         DateTimeOffset? from,
         DateTimeOffset? to,
         string? search,

--- a/Tests/Services.Events.Tests/EventReadServiceTests.cs
+++ b/Tests/Services.Events.Tests/EventReadServiceTests.cs
@@ -1,0 +1,372 @@
+using System.Linq;
+using BusinessObjects;
+using BusinessObjects.Common.Results;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Repositories.Implements;
+using Repositories.Interfaces;
+using Repositories.Persistence;
+using Services.Implementations;
+using Xunit;
+
+namespace Services.Events.Tests;
+
+public sealed class EventReadServiceTests
+{
+    [Fact]
+    public async Task GetById_ShouldReturnEvent_WhenActive()
+    {
+        await using var ctx = await EventTestContext.CreateAsync();
+        var organizerId = Guid.NewGuid();
+        var attendeeId = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+
+        var ev = new Event
+        {
+            Id = Guid.NewGuid(),
+            OrganizerId = organizerId,
+            Title = "LAN Party",
+            Description = "Bring your laptop",
+            Mode = EventMode.Onsite,
+            StartsAt = now.AddDays(2),
+            EndsAt = now.AddDays(2).AddHours(4),
+            Status = EventStatus.Open,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = organizerId
+        };
+        ctx.Db.Events.Add(ev);
+
+        ctx.Db.Escrows.Add(new Escrow
+        {
+            Id = Guid.NewGuid(),
+            EventId = ev.Id,
+            AmountHoldCents = 150_000,
+            Status = EscrowStatus.Held,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = organizerId
+        });
+
+        ctx.Db.EventRegistrations.Add(new EventRegistration
+        {
+            Id = Guid.NewGuid(),
+            EventId = ev.Id,
+            UserId = attendeeId,
+            Status = EventRegistrationStatus.Confirmed,
+            RegisteredAt = now,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = attendeeId
+        });
+
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.EventReadService.GetByIdAsync(attendeeId, ev.Id);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Id.Should().Be(ev.Id);
+        result.Value.Title.Should().Be("LAN Party");
+        result.Value.MyRegistrationStatus.Should().Be(EventRegistrationStatus.Confirmed);
+        result.Value.IsOrganizer.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturnNotFound_WhenSoftDeleted()
+    {
+        await using var ctx = await EventTestContext.CreateAsync();
+        var ev = new Event
+        {
+            Id = Guid.NewGuid(),
+            OrganizerId = Guid.NewGuid(),
+            Title = "Deleted Event",
+            Status = EventStatus.Draft,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            IsDeleted = true,
+            DeletedAtUtc = DateTime.UtcNow
+        };
+        ctx.Db.Events.Add(ev);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.EventReadService.GetByIdAsync(Guid.NewGuid(), ev.Id);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().NotBeNull();
+        result.Error!.Code.Should().Be(Error.Codes.NotFound);
+    }
+
+    [Fact]
+    public async Task SearchAsync_ShouldRespectFilters()
+    {
+        await using var ctx = await EventTestContext.CreateAsync();
+        var organizerId = Guid.NewGuid();
+        var communityId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+
+        var matching = new Event
+        {
+            Id = Guid.NewGuid(),
+            OrganizerId = organizerId,
+            CommunityId = communityId,
+            Title = "LAN Marathon",
+            Description = "Weekend LAN party",
+            Status = EventStatus.Open,
+            StartsAt = now.AddDays(1),
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = organizerId
+        };
+        ctx.Db.Events.Add(matching);
+
+        var differentStatus = new Event
+        {
+            Id = Guid.NewGuid(),
+            OrganizerId = organizerId,
+            CommunityId = communityId,
+            Title = "LAN Closed",
+            Status = EventStatus.Completed,
+            StartsAt = now.AddDays(1),
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = organizerId
+        };
+        ctx.Db.Events.Add(differentStatus);
+
+        var outsideWindow = new Event
+        {
+            Id = Guid.NewGuid(),
+            OrganizerId = organizerId,
+            CommunityId = communityId,
+            Title = "LAN Future",
+            Status = EventStatus.Open,
+            StartsAt = now.AddDays(10),
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = organizerId
+        };
+        ctx.Db.Events.Add(outsideWindow);
+
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.EventReadService.SearchAsync(
+            userId,
+            new[] { EventStatus.Open },
+            communityId,
+            organizerId,
+            now,
+            now.AddDays(2),
+            "LAN",
+            sortAscByStartsAt: true,
+            page: 1,
+            pageSize: 10);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Items.Should().HaveCount(1);
+        result.Value.Items[0].Id.Should().Be(matching.Id);
+        result.Value.TotalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ListForEvent_ShouldAllowOrganizer_AndRejectOthers()
+    {
+        await using var ctx = await EventTestContext.CreateAsync();
+        var organizerId = Guid.NewGuid();
+        var eventId = Guid.NewGuid();
+        var attendeeId = Guid.NewGuid();
+
+        ctx.Db.Events.Add(new Event
+        {
+            Id = eventId,
+            OrganizerId = organizerId,
+            Title = "Organizer View",
+            Status = EventStatus.Open,
+            StartsAt = DateTimeOffset.UtcNow.AddDays(1),
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = organizerId
+        });
+
+        ctx.Db.EventRegistrations.Add(new EventRegistration
+        {
+            Id = Guid.NewGuid(),
+            EventId = eventId,
+            UserId = attendeeId,
+            Status = EventRegistrationStatus.Pending,
+            RegisteredAt = DateTimeOffset.UtcNow,
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = attendeeId
+        });
+
+        await ctx.Db.SaveChangesAsync();
+
+        var success = await ctx.RegistrationReadService.ListForEventAsync(organizerId, eventId, null, 1, 10);
+        success.IsSuccess.Should().BeTrue();
+        success.Value!.Items.Should().HaveCount(1);
+        success.Value.Items[0].UserId.Should().Be(attendeeId);
+
+        var forbidden = await ctx.RegistrationReadService.ListForEventAsync(Guid.NewGuid(), eventId, null, 1, 10);
+        forbidden.IsSuccess.Should().BeFalse();
+        forbidden.Error!.Code.Should().Be(Error.Codes.Forbidden);
+    }
+
+    [Fact]
+    public async Task ListMine_ShouldReturnOnlyCurrentUserRegistrations()
+    {
+        await using var ctx = await EventTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        var event1 = Guid.NewGuid();
+        var event2 = Guid.NewGuid();
+
+        ctx.Db.Events.AddRange(
+            new Event
+            {
+                Id = event1,
+                OrganizerId = Guid.NewGuid(),
+                Title = "Event A",
+                Status = EventStatus.Open,
+                StartsAt = DateTimeOffset.UtcNow.AddDays(1),
+                CreatedAtUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid()
+            },
+            new Event
+            {
+                Id = event2,
+                OrganizerId = Guid.NewGuid(),
+                Title = "Event B",
+                Status = EventStatus.Open,
+                StartsAt = DateTimeOffset.UtcNow.AddDays(2),
+                CreatedAtUtc = DateTime.UtcNow,
+                CreatedBy = Guid.NewGuid()
+            });
+
+        ctx.Db.EventRegistrations.AddRange(
+            new EventRegistration
+            {
+                Id = Guid.NewGuid(),
+                EventId = event1,
+                UserId = userId,
+                Status = EventRegistrationStatus.Confirmed,
+                RegisteredAt = DateTimeOffset.UtcNow,
+                CreatedAtUtc = DateTime.UtcNow,
+                CreatedBy = userId
+            },
+            new EventRegistration
+            {
+                Id = Guid.NewGuid(),
+                EventId = event2,
+                UserId = userId,
+                Status = EventRegistrationStatus.Pending,
+                RegisteredAt = DateTimeOffset.UtcNow,
+                CreatedAtUtc = DateTime.UtcNow,
+                CreatedBy = userId
+            },
+            new EventRegistration
+            {
+                Id = Guid.NewGuid(),
+                EventId = event2,
+                UserId = otherUserId,
+                Status = EventRegistrationStatus.Pending,
+                RegisteredAt = DateTimeOffset.UtcNow,
+                CreatedAtUtc = DateTime.UtcNow,
+                CreatedBy = otherUserId
+            });
+
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.RegistrationReadService.ListMineAsync(userId, null, 1, 10);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Should().HaveCount(2);
+        result.Value.Items.Should().OnlyContain(r => r.EventId == event1 || r.EventId == event2);
+        result.Value.Items.Select(r => r.EventTitle).Should().BeEquivalentTo(new[] { "Event A", "Event B" });
+    }
+
+    [Fact]
+    public async Task PaymentRead_ShouldReturnIntent_ForOwnerOnly()
+    {
+        await using var ctx = await EventTestContext.CreateAsync();
+        var ownerId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+
+        var intent = new PaymentIntent
+        {
+            Id = Guid.NewGuid(),
+            UserId = ownerId,
+            AmountCents = 123_000,
+            Purpose = PaymentPurpose.EventTicket,
+            Status = PaymentIntentStatus.RequiresPayment,
+            ClientSecret = "secret",
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(30),
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = ownerId
+        };
+        ctx.Db.PaymentIntents.Add(intent);
+        await ctx.Db.SaveChangesAsync();
+
+        var success = await ctx.PaymentReadService.GetAsync(ownerId, intent.Id);
+        success.IsSuccess.Should().BeTrue();
+        success.Value!.Id.Should().Be(intent.Id);
+
+        var failure = await ctx.PaymentReadService.GetAsync(otherUserId, intent.Id);
+        failure.IsSuccess.Should().BeFalse();
+        failure.Error!.Code.Should().Be(Error.Codes.NotFound);
+    }
+
+    private sealed class EventTestContext : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+
+        private EventTestContext(
+            SqliteConnection connection,
+            AppDbContext db,
+            IEventReadService eventReadService,
+            IRegistrationReadService registrationReadService,
+            IPaymentReadService paymentReadService)
+        {
+            _connection = connection;
+            Db = db;
+            EventReadService = eventReadService;
+            RegistrationReadService = registrationReadService;
+            PaymentReadService = paymentReadService;
+        }
+
+        public AppDbContext Db { get; }
+        public IEventReadService EventReadService { get; }
+        public IRegistrationReadService RegistrationReadService { get; }
+        public IPaymentReadService PaymentReadService { get; }
+
+        public static async Task<EventTestContext> CreateAsync()
+        {
+            var connection = new SqliteConnection("Filename=:memory:");
+            await connection.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var db = new AppDbContext(options);
+            await db.Database.EnsureCreatedAsync();
+
+            IEventQueryRepository eventQueryRepository = new EventQueryRepository(db);
+            IRegistrationQueryRepository registrationQueryRepository = new RegistrationQueryRepository(db);
+            var escrowRepository = new EscrowRepository(db);
+            var paymentIntentRepository = new PaymentIntentRepository(db);
+
+            var eventReadService = new EventReadService(eventQueryRepository, escrowRepository, registrationQueryRepository);
+            var registrationReadService = new RegistrationReadService(eventQueryRepository, registrationQueryRepository);
+            var paymentReadService = new PaymentReadService(paymentIntentRepository);
+
+            return new EventTestContext(
+                connection,
+                db,
+                eventReadService,
+                registrationReadService,
+                paymentReadService);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+}

--- a/Tests/Services.Events.Tests/Services.Events.Tests.csproj
+++ b/Tests/Services.Events.Tests/Services.Events.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Services\Services.csproj" />
+    <ProjectReference Include="..\..\Repositories\Repositories.csproj" />
+    <ProjectReference Include="..\..\DTOs\DTOs.csproj" />
+    <ProjectReference Include="..\..\BusinessObjects\BusinessObjects.csproj" />
+  </ItemGroup>
+</Project>

--- a/WebAPI/Controllers/EventsController.cs
+++ b/WebAPI/Controllers/EventsController.cs
@@ -1,0 +1,285 @@
+using DTOs.Common;
+using DTOs.Events;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace WebAPI.Controllers;
+
+[ApiController]
+[Route("api/events")]
+[Authorize]
+public sealed class EventsController : ControllerBase
+{
+    private const int MaxPageSize = 100;
+
+    private readonly IEventService _eventService;
+    private readonly IEventReadService _eventReadService;
+
+    public EventsController(IEventService eventService, IEventReadService eventReadService)
+    {
+        _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
+        _eventReadService = eventReadService ?? throw new ArgumentNullException(nameof(eventReadService));
+    }
+
+    [HttpPost]
+    [EnableRateLimiting("EventsWrite")]
+    [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> Create([FromBody] EventCreateRequestDto request, CancellationToken ct)
+    {
+        if (request is null)
+        {
+            return this.ToActionResult(Result<Guid>.Failure(new Error(Error.Codes.Validation, "Request body is required.")));
+        }
+
+        var organizerId = User.GetUserId();
+        if (!organizerId.HasValue)
+        {
+            return this.ToActionResult(Result<Guid>.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        var result = await _eventService.CreateAsync(organizerId.Value, request, ct).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            return this.ToActionResult(result);
+        }
+
+        return this.ToCreatedAtAction(
+            result,
+            nameof(GetById),
+            new { id = result.Value },
+            id => new { eventId = id });
+    }
+
+    [HttpPost("{eventId:guid}/open")]
+    [EnableRateLimiting("EventsWrite")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(object), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> Open(Guid eventId, CancellationToken ct)
+    {
+        var organizerId = User.GetUserId();
+        if (!organizerId.HasValue)
+        {
+            return this.ToActionResult(Result.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        var result = await _eventService.OpenAsync(organizerId.Value, eventId, ct).ConfigureAwait(false);
+        if (!result.IsSuccess && result.Error.Code == Error.Codes.Forbidden &&
+            TryParseTopUpNeeded(result.Error.Message, out var needed))
+        {
+            return StatusCode(StatusCodes.Status403Forbidden, new { topUpNeededCents = needed });
+        }
+
+        return this.ToActionResult(result);
+    }
+
+    [HttpPost("{eventId:guid}/cancel")]
+    [EnableRateLimiting("EventsWrite")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> Cancel(Guid eventId, CancellationToken ct)
+    {
+        var organizerId = User.GetUserId();
+        if (!organizerId.HasValue)
+        {
+            return this.ToActionResult(Result.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        var result = await _eventService.CancelAsync(organizerId.Value, eventId, ct).ConfigureAwait(false);
+        return this.ToActionResult(result);
+    }
+
+    [HttpGet("{eventId:guid}")]
+    [EnableRateLimiting("ReadsLight")]
+    [ProducesResponseType(typeof(EventDetailDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> GetById(Guid eventId, CancellationToken ct)
+    {
+        var currentUserId = User.GetUserId();
+        if (!currentUserId.HasValue)
+        {
+            return this.ToActionResult(Result<EventDetailDto>.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        var result = await _eventReadService.GetByIdAsync(currentUserId.Value, eventId, ct).ConfigureAwait(false);
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+
+    [HttpGet]
+    [EnableRateLimiting("ReadsHeavy")]
+    [ProducesResponseType(typeof(PagedResponse<EventDetailDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> Search(
+        [FromQuery(Name = "status")] IEnumerable<EventStatus>? statuses,
+        [FromQuery] Guid? communityId,
+        [FromQuery] Guid? organizerId,
+        [FromQuery] DateTimeOffset? from,
+        [FromQuery] DateTimeOffset? to,
+        [FromQuery] string? search,
+        [FromQuery] string? sort,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = PaginationOptions.DefaultPageSize,
+        CancellationToken ct = default)
+    {
+        var currentUserId = User.GetUserId();
+        if (!currentUserId.HasValue)
+        {
+            return this.ToActionResult(Result<PagedResponse<EventDetailDto>>.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        if (!TryParseSort(sort, out var sortAsc, out var sortError))
+        {
+            var failure = Result<PagedResponse<EventDetailDto>>.Failure(new Error(Error.Codes.Validation, sortError!));
+            return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
+        }
+
+        var normalizedPage = page < 1 ? 1 : page;
+        var normalizedPageSize = pageSize <= 0
+            ? PaginationOptions.DefaultPageSize
+            : Math.Clamp(pageSize, 1, Math.Min(PaginationOptions.MaxPageSize, MaxPageSize));
+
+        var result = await _eventReadService.SearchAsync(
+            currentUserId.Value,
+            statuses,
+            communityId,
+            organizerId,
+            from,
+            to,
+            search,
+            sortAsc,
+            normalizedPage,
+            normalizedPageSize,
+            ct).ConfigureAwait(false);
+
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+
+    [HttpGet("~/api/organizer/events")]
+    [EnableRateLimiting("ReadsHeavy")]
+    [ProducesResponseType(typeof(PagedResponse<EventDetailDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> ListMyEvents(
+        [FromQuery(Name = "status")] IEnumerable<EventStatus>? statuses,
+        [FromQuery] Guid? communityId,
+        [FromQuery] DateTimeOffset? from,
+        [FromQuery] DateTimeOffset? to,
+        [FromQuery] string? search,
+        [FromQuery] string? sort,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = PaginationOptions.DefaultPageSize,
+        CancellationToken ct = default)
+    {
+        var organizerId = User.GetUserId();
+        if (!organizerId.HasValue)
+        {
+            return this.ToActionResult(Result<PagedResponse<EventDetailDto>>.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        if (!TryParseSort(sort, out var sortAsc, out var sortError))
+        {
+            var failure = Result<PagedResponse<EventDetailDto>>.Failure(new Error(Error.Codes.Validation, sortError!));
+            return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
+        }
+
+        var normalizedPage = page < 1 ? 1 : page;
+        var normalizedPageSize = pageSize <= 0
+            ? PaginationOptions.DefaultPageSize
+            : Math.Clamp(pageSize, 1, Math.Min(PaginationOptions.MaxPageSize, MaxPageSize));
+
+        var result = await _eventReadService.SearchMyOrganizedAsync(
+            organizerId.Value,
+            statuses,
+            communityId,
+            from,
+            to,
+            search,
+            sortAsc,
+            normalizedPage,
+            normalizedPageSize,
+            ct).ConfigureAwait(false);
+
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+
+    private static bool TryParseTopUpNeeded(string? message, out long needed)
+    {
+        needed = 0;
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return false;
+        }
+
+        const string token = "topUpNeededCents=";
+        var index = message.IndexOf(token, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+        {
+            return false;
+        }
+
+        var start = index + token.Length;
+        var span = message.AsSpan(start);
+        var endIndex = span.IndexOfAny(' ', '.', ',', ';');
+        var numberSpan = endIndex >= 0 ? span[..endIndex] : span;
+        return long.TryParse(numberSpan, out needed);
+    }
+
+    private static bool TryParseSort(string? sort, out bool sortAsc, out string? error)
+    {
+        sortAsc = true;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(sort))
+        {
+            return true;
+        }
+
+        var normalized = sort.Trim();
+        var lower = normalized.ToLowerInvariant();
+
+        if (lower is "startsat" or "startsat:asc" or "startsat_asc" or "startsat asc" or "asc" or "+startsat")
+        {
+            sortAsc = true;
+            return true;
+        }
+
+        if (lower is "-startsat" or "startsat:desc" or "startsat_desc" or "startsat desc" or "desc")
+        {
+            sortAsc = false;
+            return true;
+        }
+
+        error = $"Invalid sort '{sort}'. Allowed values: StartsAt, -StartsAt.";
+        return false;
+    }
+}

--- a/WebAPI/Controllers/PaymentsController.cs
+++ b/WebAPI/Controllers/PaymentsController.cs
@@ -1,0 +1,63 @@
+using DTOs.Registrations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace WebAPI.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/payments")]
+public sealed class PaymentsController : ControllerBase
+{
+    private readonly IPaymentService _paymentService;
+    private readonly IPaymentReadService _paymentReadService;
+
+    public PaymentsController(IPaymentService paymentService, IPaymentReadService paymentReadService)
+    {
+        _paymentService = paymentService ?? throw new ArgumentNullException(nameof(paymentService));
+        _paymentReadService = paymentReadService ?? throw new ArgumentNullException(nameof(paymentReadService));
+    }
+
+    [HttpPost("{intentId:guid}/confirm")]
+    [EnableRateLimiting("PaymentsWrite")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> Confirm(Guid intentId, CancellationToken ct)
+    {
+        var currentUserId = User.GetUserId();
+        if (!currentUserId.HasValue)
+        {
+            return this.ToActionResult(Result.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        var result = await _paymentService.ConfirmAsync(currentUserId.Value, intentId, ct).ConfigureAwait(false);
+        return this.ToActionResult(result);
+    }
+
+    [HttpGet("{intentId:guid}")]
+    [EnableRateLimiting("ReadsLight")]
+    [ProducesResponseType(typeof(PaymentIntentDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> Get(Guid intentId, CancellationToken ct)
+    {
+        var currentUserId = User.GetUserId();
+        if (!currentUserId.HasValue)
+        {
+            return this.ToActionResult(Result<PaymentIntentDto>.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        var result = await _paymentReadService.GetAsync(currentUserId.Value, intentId, ct).ConfigureAwait(false);
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+}

--- a/WebAPI/Controllers/RegistrationsController.cs
+++ b/WebAPI/Controllers/RegistrationsController.cs
@@ -1,0 +1,122 @@
+using DTOs.Common;
+using DTOs.Registrations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace WebAPI.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/events/{eventId:guid}/registrations")]
+public sealed class RegistrationsController : ControllerBase
+{
+    private const int MaxPageSize = 100;
+
+    private readonly IRegistrationService _registrationService;
+    private readonly IRegistrationReadService _registrationReadService;
+
+    public RegistrationsController(
+        IRegistrationService registrationService,
+        IRegistrationReadService registrationReadService)
+    {
+        _registrationService = registrationService ?? throw new ArgumentNullException(nameof(registrationService));
+        _registrationReadService = registrationReadService ?? throw new ArgumentNullException(nameof(registrationReadService));
+    }
+
+    [HttpPost]
+    [EnableRateLimiting("RegistrationsWrite")]
+    [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> Register(Guid eventId, CancellationToken ct)
+    {
+        var currentUserId = User.GetUserId();
+        if (!currentUserId.HasValue)
+        {
+            return this.ToActionResult(Result<Guid>.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        var result = await _registrationService.RegisterAsync(currentUserId.Value, eventId, ct).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            return this.ToActionResult(result);
+        }
+
+        return this.ToCreatedAtAction(
+            result,
+            nameof(GetByEvent),
+            new { eventId, page = 1, pageSize = PaginationOptions.DefaultPageSize },
+            id => new { paymentIntentId = id });
+    }
+
+    [HttpGet]
+    [EnableRateLimiting("ReadsHeavy")]
+    [ProducesResponseType(typeof(PagedResponse<RegistrationListItemDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> GetByEvent(
+        Guid eventId,
+        [FromQuery(Name = "status")] IEnumerable<EventRegistrationStatus>? statuses,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = PaginationOptions.DefaultPageSize,
+        CancellationToken ct = default)
+    {
+        var organizerId = User.GetUserId();
+        if (!organizerId.HasValue)
+        {
+            return this.ToActionResult(Result<PagedResponse<RegistrationListItemDto>>.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        var normalizedPage = page < 1 ? 1 : page;
+        var normalizedPageSize = pageSize <= 0
+            ? PaginationOptions.DefaultPageSize
+            : Math.Clamp(pageSize, 1, Math.Min(PaginationOptions.MaxPageSize, MaxPageSize));
+
+        var result = await _registrationReadService
+            .ListForEventAsync(organizerId.Value, eventId, statuses, normalizedPage, normalizedPageSize, ct)
+            .ConfigureAwait(false);
+
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+
+    [HttpGet("~/api/me/registrations")]
+    [EnableRateLimiting("ReadsLight")]
+    [ProducesResponseType(typeof(PagedResponse<MyRegistrationDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> GetMine(
+        [FromQuery(Name = "status")] IEnumerable<EventRegistrationStatus>? statuses,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = PaginationOptions.DefaultPageSize,
+        CancellationToken ct = default)
+    {
+        var currentUserId = User.GetUserId();
+        if (!currentUserId.HasValue)
+        {
+            return this.ToActionResult(Result<PagedResponse<MyRegistrationDto>>.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        var normalizedPage = page < 1 ? 1 : page;
+        var normalizedPageSize = pageSize <= 0
+            ? PaginationOptions.DefaultPageSize
+            : Math.Clamp(pageSize, 1, Math.Min(PaginationOptions.MaxPageSize, MaxPageSize));
+
+        var result = await _registrationReadService
+            .ListMineAsync(currentUserId.Value, statuses, normalizedPage, normalizedPageSize, ct)
+            .ConfigureAwait(false);
+
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+}

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -26,6 +26,91 @@ public static class ServiceCollectionExtensions
         {
             options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
 
+            options.AddPolicy("EventsWrite", httpContext =>
+            {
+                var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
+
+                return PartitionedRateLimiter.CreateChained(
+                    RateLimitPartition.GetTokenBucketLimiter($"{userKey}:events:minute", _ => new TokenBucketRateLimiterOptions
+                    {
+                        TokenLimit = 60,
+                        TokensPerPeriod = 60,
+                        ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0,
+                        AutoReplenishment = true
+                    }),
+                    RateLimitPartition.GetTokenBucketLimiter($"{userKey}:events:day", _ => new TokenBucketRateLimiterOptions
+                    {
+                        TokenLimit = 20,
+                        TokensPerPeriod = 20,
+                        ReplenishmentPeriod = TimeSpan.FromDays(1),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0,
+                        AutoReplenishment = true
+                    }));
+            });
+
+            options.AddPolicy("RegistrationsWrite", httpContext =>
+            {
+                var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
+
+                return RateLimitPartition.GetTokenBucketLimiter(userKey, _ => new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = 60,
+                    TokensPerPeriod = 60,
+                    ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                });
+            });
+
+            options.AddPolicy("PaymentsWrite", httpContext =>
+            {
+                var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
+
+                return RateLimitPartition.GetTokenBucketLimiter(userKey, _ => new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = 120,
+                    TokensPerPeriod = 120,
+                    ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                });
+            });
+
+            options.AddPolicy("ReadsHeavy", httpContext =>
+            {
+                var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
+
+                return RateLimitPartition.GetTokenBucketLimiter(userKey, _ => new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = 300,
+                    TokensPerPeriod = 300,
+                    ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                });
+            });
+
+            options.AddPolicy("ReadsLight", httpContext =>
+            {
+                var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
+
+                return RateLimitPartition.GetTokenBucketLimiter(userKey, _ => new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = 600,
+                    TokensPerPeriod = 600,
+                    ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                });
+            });
+
             options.AddPolicy("FriendInvite", httpContext =>
             {
                 var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();


### PR DESCRIPTION
## Summary
- add authorized Events, Registrations, and Payments controllers with new read endpoints and result handling
- update event query services to ignore soft-deleted rows, support organizer filtering, and apply new rate limit policies
- introduce xUnit coverage for event, registration, and payment read flows

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ec58a072bc832daac12a7dac698670