### PR TITLE
Add game catalog services and APIs

### DIFF
--- a/DTOs/Games/GameCreateRequestDto.cs
+++ b/DTOs/Games/GameCreateRequestDto.cs
@@ -1,0 +1,6 @@
+namespace DTOs.Games;
+
+/// <summary>
+/// Request payload for creating a new game.
+/// </summary>
+public sealed record GameCreateRequestDto(string Name);

--- a/DTOs/Games/GameDto.cs
+++ b/DTOs/Games/GameDto.cs
@@ -1,0 +1,8 @@
+namespace DTOs.Games;
+
+/// <summary>
+/// Lightweight game catalog item.
+/// </summary>
+public sealed record GameDto(
+    Guid Id,
+    string Name);

--- a/DTOs/Games/GameRenameRequestDto.cs
+++ b/DTOs/Games/GameRenameRequestDto.cs
@@ -1,0 +1,6 @@
+namespace DTOs.Games;
+
+/// <summary>
+/// Request payload for renaming an existing game.
+/// </summary>
+public sealed record GameRenameRequestDto(string Name);

--- a/DTOs/Games/UserGameDto.cs
+++ b/DTOs/Games/UserGameDto.cs
@@ -1,0 +1,13 @@
+using BusinessObjects.Common;
+
+namespace DTOs.Games;
+
+/// <summary>
+/// Represents a user's association with a game.
+/// </summary>
+public sealed record UserGameDto(
+    Guid GameId,
+    string GameName,
+    string? InGameName,
+    GameSkillLevel? Skill,
+    DateTimeOffset AddedAt);

--- a/DTOs/Games/UserGameUpsertRequestDto.cs
+++ b/DTOs/Games/UserGameUpsertRequestDto.cs
@@ -1,0 +1,10 @@
+using BusinessObjects.Common;
+
+namespace DTOs.Games;
+
+/// <summary>
+/// Request payload for creating or updating a user-game relation.
+/// </summary>
+public sealed record UserGameUpsertRequestDto(
+    string? InGameName,
+    GameSkillLevel? Skill);

--- a/Repositories/DependencyInjection/InfrastructureRegistration.cs
+++ b/Repositories/DependencyInjection/InfrastructureRegistration.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Repositories.Interfaces;
 using Repositories.Implements;
+using Repositories.Persistence.Seeding;
 
 namespace Repositories.DependencyInjection
 {
@@ -95,6 +96,9 @@ namespace Repositories.DependencyInjection
             services.AddScoped<IWalletRepository, WalletRepository>();
             services.AddScoped<ITransactionRepository, TransactionRepository>();
             services.AddScoped<IPaymentIntentRepository, PaymentIntentRepository>();
+            services.AddScoped<IGameRepository, GameRepository>();
+            services.AddScoped<IUserGameRepository, UserGameRepository>();
+            services.AddScoped<IAppSeeder, AppSeeder>();
 
             // 6) Hosted seeding
             services.AddHostedService<DbInitializerHostedService>();

--- a/Repositories/Implements/GameRepository.cs
+++ b/Repositories/Implements/GameRepository.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Repositories.Implements;
+
+/// <summary>
+/// Entity Framework implementation for <see cref="IGameRepository"/>.
+/// </summary>
+public sealed class GameRepository : IGameRepository
+{
+    private readonly AppDbContext _context;
+
+    public GameRepository(AppDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public IQueryable<Game> Query() => _context.Games.AsNoTracking();
+
+    public Task<Game?> GetByIdAsync(Guid id, CancellationToken ct = default)
+        => _context.Games.FirstOrDefaultAsync(g => g.Id == id, ct);
+
+    public Task<Game?> GetByNameInsensitiveAsync(string name, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Game name is required.", nameof(name));
+
+        var trimmed = name.Trim();
+        var query = _context.Games.AsNoTracking();
+
+        if (_context.Database.IsNpgsql())
+        {
+            return query.FirstOrDefaultAsync(g => EF.Functions.ILike(g.Name, trimmed), ct);
+        }
+
+        var normalized = trimmed.ToLowerInvariant();
+        return query.FirstOrDefaultAsync(g => g.Name.ToLower() == normalized, ct);
+    }
+
+    public async Task CreateAsync(Game game, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(game);
+        await _context.Games.AddAsync(game, ct).ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(Game game, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(game);
+        _context.Games.Update(game);
+        return Task.CompletedTask;
+    }
+
+    public Task SoftDeleteAsync(Game game, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(game);
+        _context.Games.Update(game);
+        return Task.CompletedTask;
+    }
+}

--- a/Repositories/Implements/UserGameRepository.cs
+++ b/Repositories/Implements/UserGameRepository.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Repositories.Implements;
+
+/// <summary>
+/// Entity Framework repository for <see cref="UserGame"/> relations.
+/// </summary>
+public sealed class UserGameRepository : IUserGameRepository
+{
+    private readonly AppDbContext _context;
+
+    public UserGameRepository(AppDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public IQueryable<UserGame> Query() => _context.UserGames.AsNoTracking();
+
+    public Task<UserGame?> GetAsync(Guid userId, Guid gameId, CancellationToken ct = default)
+        => _context.UserGames.FirstOrDefaultAsync(ug => ug.UserId == userId && ug.GameId == gameId, ct);
+
+    public async Task<IReadOnlyList<UserGame>> ListByUserAsync(Guid userId, CancellationToken ct = default)
+    {
+        return await _context.UserGames
+            .AsNoTracking()
+            .Where(ug => ug.UserId == userId)
+            .OrderByDescending(ug => ug.AddedAt)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task CreateAsync(UserGame userGame, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(userGame);
+        await _context.UserGames.AddAsync(userGame, ct).ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(UserGame userGame, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(userGame);
+        _context.UserGames.Update(userGame);
+        return Task.CompletedTask;
+    }
+
+    public async Task RemoveAsync(Guid userId, Guid gameId, CancellationToken ct = default)
+    {
+        var entity = await _context.UserGames.FindAsync(new object[] { userId, gameId }, ct).ConfigureAwait(false);
+        if (entity is null)
+            return;
+
+        _context.UserGames.Remove(entity);
+    }
+}

--- a/Repositories/Interfaces/IGameRepository.cs
+++ b/Repositories/Interfaces/IGameRepository.cs
@@ -1,0 +1,37 @@
+namespace Repositories.Interfaces;
+
+/// <summary>
+/// Repository for querying and persisting <see cref="Game"/> entities.
+/// </summary>
+public interface IGameRepository
+{
+    /// <summary>
+    /// Returns a queryable for games (soft-delete filter applied automatically).
+    /// </summary>
+    IQueryable<Game> Query();
+
+    /// <summary>
+    /// Finds a game by identifier.
+    /// </summary>
+    Task<Game?> GetByIdAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Finds a game by name ignoring casing (soft-deleted records are skipped).
+    /// </summary>
+    Task<Game?> GetByNameInsensitiveAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists a new game.
+    /// </summary>
+    Task CreateAsync(Game game, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates an existing game.
+    /// </summary>
+    Task UpdateAsync(Game game, CancellationToken ct = default);
+
+    /// <summary>
+    /// Applies soft-delete changes to an existing game.
+    /// </summary>
+    Task SoftDeleteAsync(Game game, CancellationToken ct = default);
+}

--- a/Repositories/Interfaces/IUserGameRepository.cs
+++ b/Repositories/Interfaces/IUserGameRepository.cs
@@ -1,0 +1,37 @@
+namespace Repositories.Interfaces;
+
+/// <summary>
+/// Repository for managing user-game relations.
+/// </summary>
+public interface IUserGameRepository
+{
+    /// <summary>
+    /// Returns a queryable for user games (soft-delete filters applied).
+    /// </summary>
+    IQueryable<UserGame> Query();
+
+    /// <summary>
+    /// Gets a specific user-game relation by identifiers.
+    /// </summary>
+    Task<UserGame?> GetAsync(Guid userId, Guid gameId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists all games for a specific user.
+    /// </summary>
+    Task<IReadOnlyList<UserGame>> ListByUserAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Creates a new user-game relation.
+    /// </summary>
+    Task CreateAsync(UserGame userGame, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates an existing relation.
+    /// </summary>
+    Task UpdateAsync(UserGame userGame, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a relation.
+    /// </summary>
+    Task RemoveAsync(Guid userId, Guid gameId, CancellationToken ct = default);
+}

--- a/Repositories/Migrations/20251016100000_GamesCatalog_Constraints_Indexes.cs
+++ b/Repositories/Migrations/20251016100000_GamesCatalog_Constraints_Indexes.cs
@@ -1,0 +1,320 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Repositories.Migrations
+{
+    /// <inheritdoc />
+    public partial class GamesCatalog_Constraints_Indexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Convert existing skill values to numeric representation before changing column type
+            if (migrationBuilder.ActiveProvider.Contains("Npgsql"))
+            {
+                migrationBuilder.Sql("""
+                    UPDATE "user_games"
+                    SET "Skill" = CASE
+                        WHEN "Skill" IN ('Casual', '0') THEN '0'
+                        WHEN "Skill" IN ('Intermediate', '1') THEN '1'
+                        WHEN "Skill" IN ('Competitive', '2') THEN '2'
+                        ELSE NULL
+                    END;
+                """);
+            }
+            else
+            {
+                migrationBuilder.Sql("""
+                    UPDATE [user_games]
+                    SET [Skill] = CASE
+                        WHEN [Skill] = 'Casual' THEN '0'
+                        WHEN [Skill] = 'Intermediate' THEN '1'
+                        WHEN [Skill] = 'Competitive' THEN '2'
+                        ELSE [Skill]
+                    END;
+                """);
+            }
+
+            // Adjust Game.Name column length/type per provider
+            if (migrationBuilder.ActiveProvider.Contains("Npgsql"))
+            {
+                migrationBuilder.AlterColumn<string>(
+                    name: "Name",
+                    table: "games",
+                    type: "character varying(128)",
+                    maxLength: 128,
+                    nullable: false,
+                    oldClrType: typeof(string),
+                    oldType: "text");
+            }
+            else
+            {
+                migrationBuilder.AlterColumn<string>(
+                    name: "Name",
+                    table: "games",
+                    type: "nvarchar(128)",
+                    maxLength: 128,
+                    nullable: false,
+                    oldClrType: typeof(string),
+                    oldType: "nvarchar(max)");
+            }
+
+            // Drop legacy indexes on user_games
+            migrationBuilder.DropIndex(
+                name: "IX_user_games_GameId",
+                table: "user_games");
+
+            migrationBuilder.DropIndex(
+                name: "IX_user_games_Skill",
+                table: "user_games");
+
+            // Change skill column to integer
+            if (migrationBuilder.ActiveProvider.Contains("Npgsql"))
+            {
+                migrationBuilder.AlterColumn<int>(
+                    name: "Skill",
+                    table: "user_games",
+                    type: "integer",
+                    nullable: true,
+                    oldClrType: typeof(string),
+                    oldType: "text",
+                    oldNullable: true);
+            }
+            else
+            {
+                migrationBuilder.AlterColumn<int>(
+                    name: "Skill",
+                    table: "user_games",
+                    type: "int",
+                    nullable: true,
+                    oldClrType: typeof(string),
+                    oldType: "nvarchar(max)",
+                    oldNullable: true);
+            }
+
+            // Drop existing foreign keys to replace with Restrict behavior
+            migrationBuilder.DropForeignKey(
+                name: "FK_user_games_games_GameId",
+                table: "user_games");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_user_games_users_UserId",
+                table: "user_games");
+
+            // Create updated indexes with explicit names
+            migrationBuilder.CreateIndex(
+                name: "IX_UserGames_GameId",
+                table: "user_games",
+                column: "GameId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserGames_Skill",
+                table: "user_games",
+                column: "Skill");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserGames_UserId",
+                table: "user_games",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Games_CreatedAtUtc",
+                table: "games",
+                column: "CreatedAtUtc");
+
+            // Provider-specific unique index on Name (case-insensitive)
+            if (migrationBuilder.ActiveProvider.Contains("Npgsql"))
+            {
+                migrationBuilder.Sql("""
+                    CREATE UNIQUE INDEX IF NOT EXISTS "IX_Games_Name_Lower_UQ"
+                    ON "games" (LOWER("Name"))
+                    WHERE "IsDeleted" = false;
+                """);
+
+                migrationBuilder.Sql("""
+                    DO $$
+                    BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1 FROM pg_constraint WHERE conname = 'CK_UserGames_Skill_Range'
+                        ) THEN
+                            ALTER TABLE "user_games"
+                            ADD CONSTRAINT "CK_UserGames_Skill_Range"
+                            CHECK ("Skill" IS NULL OR "Skill" BETWEEN 0 AND 2);
+                        END IF;
+                    END$$;
+                """);
+            }
+            else
+            {
+                migrationBuilder.CreateIndex(
+                    name: "IX_Games_Name_CI",
+                    table: "games",
+                    column: "Name",
+                    unique: true,
+                    filter: "[IsDeleted] = 0");
+
+                migrationBuilder.AddCheckConstraint(
+                    name: "CK_UserGames_Skill_Range",
+                    table: "user_games",
+                    sql: "[Skill] IS NULL OR [Skill] BETWEEN 0 AND 2");
+            }
+
+            // Re-add foreign keys with Restrict delete behavior
+            migrationBuilder.AddForeignKey(
+                name: "FK_user_games_games_GameId",
+                table: "user_games",
+                column: "GameId",
+                principalTable: "games",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_user_games_users_UserId",
+                table: "user_games",
+                column: "UserId",
+                principalTable: "users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Remove foreign keys with Restrict behavior
+            migrationBuilder.DropForeignKey(
+                name: "FK_user_games_games_GameId",
+                table: "user_games");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_user_games_users_UserId",
+                table: "user_games");
+
+            // Drop new indexes
+            migrationBuilder.DropIndex(
+                name: "IX_UserGames_GameId",
+                table: "user_games");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserGames_Skill",
+                table: "user_games");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserGames_UserId",
+                table: "user_games");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Games_CreatedAtUtc",
+                table: "games");
+
+            if (migrationBuilder.ActiveProvider.Contains("Npgsql"))
+            {
+                migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_Games_Name_Lower_UQ\";");
+                migrationBuilder.Sql("""
+                    ALTER TABLE "user_games"
+                    DROP CONSTRAINT IF EXISTS "CK_UserGames_Skill_Range";
+                """);
+            }
+            else
+            {
+                migrationBuilder.DropIndex(
+                    name: "IX_Games_Name_CI",
+                    table: "games");
+
+                migrationBuilder.DropCheckConstraint(
+                    name: "CK_UserGames_Skill_Range",
+                    table: "user_games");
+            }
+
+            // Convert skill values back to string representation before altering column type
+            if (migrationBuilder.ActiveProvider.Contains("Npgsql"))
+            {
+                migrationBuilder.Sql("""
+                    UPDATE "user_games"
+                    SET "Skill" = CASE
+                        WHEN "Skill" = 0 THEN 'Casual'
+                        WHEN "Skill" = 1 THEN 'Intermediate'
+                        WHEN "Skill" = 2 THEN 'Competitive'
+                        ELSE NULL
+                    END;
+                """);
+
+                migrationBuilder.AlterColumn<string>(
+                    name: "Skill",
+                    table: "user_games",
+                    type: "text",
+                    nullable: true,
+                    oldClrType: typeof(int),
+                    oldType: "integer",
+                    oldNullable: true);
+
+                migrationBuilder.AlterColumn<string>(
+                    name: "Name",
+                    table: "games",
+                    type: "text",
+                    nullable: false,
+                    oldClrType: typeof(string),
+                    oldType: "character varying(128)",
+                    oldMaxLength: 128);
+            }
+            else
+            {
+                migrationBuilder.Sql("""
+                    UPDATE [user_games]
+                    SET [Skill] = CASE
+                        WHEN [Skill] = 0 THEN 'Casual'
+                        WHEN [Skill] = 1 THEN 'Intermediate'
+                        WHEN [Skill] = 2 THEN 'Competitive'
+                        ELSE NULL
+                    END;
+                """);
+
+                migrationBuilder.AlterColumn<string>(
+                    name: "Skill",
+                    table: "user_games",
+                    type: "nvarchar(max)",
+                    nullable: true,
+                    oldClrType: typeof(int),
+                    oldType: "int",
+                    oldNullable: true);
+
+                migrationBuilder.AlterColumn<string>(
+                    name: "Name",
+                    table: "games",
+                    type: "nvarchar(max)",
+                    nullable: false,
+                    oldClrType: typeof(string),
+                    oldType: "nvarchar(128)",
+                    oldMaxLength: 128);
+            }
+
+            // Recreate previous indexes
+            migrationBuilder.CreateIndex(
+                name: "IX_user_games_GameId",
+                table: "user_games",
+                column: "GameId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_games_Skill",
+                table: "user_games",
+                column: "Skill");
+
+            // Restore cascading foreign keys
+            migrationBuilder.AddForeignKey(
+                name: "FK_user_games_games_GameId",
+                table: "user_games",
+                column: "GameId",
+                principalTable: "games",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_user_games_users_UserId",
+                table: "user_games",
+                column: "UserId",
+                principalTable: "users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Repositories/Migrations/AppDbContextModelSnapshot.cs
+++ b/Repositories/Migrations/AppDbContextModelSnapshot.cs
@@ -118,7 +118,8 @@ namespace Repositories.Migrations
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
 
                     b.Property<DateTime?>("UpdatedAtUtc")
                         .HasColumnType("timestamp with time zone");
@@ -170,7 +171,8 @@ namespace Repositories.Migrations
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("School")
                         .HasColumnType("text");
@@ -521,6 +523,9 @@ namespace Repositories.Migrations
                         .HasColumnType("uuid");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("CreatedAtUtc")
+                        .HasDatabaseName("IX_Games_CreatedAtUtc");
 
                     b.ToTable("games", (string)null);
                 });
@@ -1123,8 +1128,8 @@ namespace Repositories.Migrations
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("boolean");
 
-                    b.Property<string>("Skill")
-                        .HasColumnType("text");
+                    b.Property<int?>("Skill")
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("UpdatedAtUtc")
                         .HasColumnType("timestamp with time zone");
@@ -1134,11 +1139,19 @@ namespace Repositories.Migrations
 
                     b.HasKey("UserId", "GameId");
 
-                    b.HasIndex("GameId");
+                    b.HasIndex("GameId")
+                        .HasDatabaseName("IX_UserGames_GameId");
 
-                    b.HasIndex("Skill");
+                    b.HasIndex("Skill")
+                        .HasDatabaseName("IX_UserGames_Skill");
 
-                    b.ToTable("user_games", (string)null);
+                    b.HasIndex("UserId")
+                        .HasDatabaseName("IX_UserGames_UserId");
+
+                    b.ToTable("user_games", null, tb =>
+                        {
+                            tb.HasCheckConstraint("CK_UserGames_Skill_Range", "\"Skill\" IS NULL OR \"Skill\" BETWEEN 0 AND 2");
+                        });
                 });
 
             modelBuilder.Entity("BusinessObjects.Wallet", b =>
@@ -1485,13 +1498,13 @@ namespace Repositories.Migrations
                     b.HasOne("BusinessObjects.Game", "Game")
                         .WithMany("Users")
                         .HasForeignKey("GameId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("BusinessObjects.User", "User")
                         .WithMany("UserGames")
                         .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("Game");

--- a/Repositories/Persistence/DbInitializerHostedService.cs
+++ b/Repositories/Persistence/DbInitializerHostedService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Repositories.Persistence.Seeding;
 
 namespace Repositories.Persistence;
 
@@ -47,6 +48,7 @@ public sealed class DbInitializerHostedService : IHostedService
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
         var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<Role>>();
+        var seeder = scope.ServiceProvider.GetService<IAppSeeder>();
 
         try
         {
@@ -58,6 +60,11 @@ public sealed class DbInitializerHostedService : IHostedService
 
             await EnsureRolesAsync(roleManager, _opt.Roles, cancellationToken);
             await EnsureAdminAsync(userManager, roleManager, _opt.Admin, cancellationToken);
+
+            if (seeder is not null)
+            {
+                await seeder.SeedAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             _logger.LogInformation("Database seeding completed successfully.");
         }

--- a/Repositories/Persistence/Seeding/AppSeeder.cs
+++ b/Repositories/Persistence/Seeding/AppSeeder.cs
@@ -1,0 +1,156 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Repositories.Persistence.Seeding;
+
+/// <summary>
+/// Seeds catalog data (games and sample user-games) for development/demo environments.
+/// </summary>
+public sealed class AppSeeder : IAppSeeder
+{
+    private static readonly string[] DefaultGames =
+    [
+        "Valorant",
+        "League of Legends",
+        "Dota 2",
+        "Apex Legends",
+        "Counter-Strike 2",
+        "Overwatch 2",
+        "PUBG: Battlegrounds",
+        "Fortnite",
+        "Rocket League",
+        "Genshin Impact"
+    ];
+
+    private readonly AppDbContext _db;
+    private readonly IGameRepository _games;
+    private readonly IUserGameRepository _userGames;
+    private readonly IGenericUnitOfWork _uow;
+    private readonly ILogger<AppSeeder> _logger;
+
+    public AppSeeder(
+        AppDbContext db,
+        IGameRepository games,
+        IUserGameRepository userGames,
+        IGenericUnitOfWork uow,
+        ILogger<AppSeeder> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _games = games ?? throw new ArgumentNullException(nameof(games));
+        _userGames = userGames ?? throw new ArgumentNullException(nameof(userGames));
+        _uow = uow ?? throw new ArgumentNullException(nameof(uow));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task SeedAsync(CancellationToken ct = default)
+    {
+        var result = await _uow.ExecuteTransactionAsync(async innerCt =>
+        {
+            var existingNames = await _games.Query()
+                .Select(g => g.Name)
+                .ToListAsync(innerCt)
+                .ConfigureAwait(false);
+
+            var comparer = StringComparer.OrdinalIgnoreCase;
+            var newGames = DefaultGames
+                .Where(name => !existingNames.Contains(name, comparer))
+                .Select(name => new Game
+                {
+                    Id = Guid.NewGuid(),
+                    Name = name.Trim()
+                })
+                .ToList();
+
+            if (newGames.Count > 0)
+            {
+                foreach (var game in newGames)
+                {
+                    await _games.CreateAsync(game, innerCt).ConfigureAwait(false);
+                }
+            }
+
+            await _uow.SaveChangesAsync(innerCt).ConfigureAwait(false);
+
+            await SeedUserGamesAsync(innerCt).ConfigureAwait(false);
+
+            await _uow.SaveChangesAsync(innerCt).ConfigureAwait(false);
+
+            return Result.Success();
+        }, ct: ct).ConfigureAwait(false);
+
+        if (result.IsFailure)
+        {
+            _logger.LogWarning("App seeding failed: {Message}", result.Error.Message);
+        }
+    }
+
+    private async Task SeedUserGamesAsync(CancellationToken ct)
+    {
+        var games = await _games.Query()
+            .Select(g => new { g.Id, g.Name })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (games.Count == 0)
+        {
+            return;
+        }
+
+        var userIds = await _db.Users
+            .AsNoTracking()
+            .Where(u => !u.IsDeleted)
+            .OrderBy(u => u.CreatedAtUtc)
+            .Select(u => u.Id)
+            .Take(10)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (userIds.Count == 0)
+        {
+            return;
+        }
+
+        var random = new Random(2025);
+
+        foreach (var userId in userIds)
+        {
+            var ownedGameIds = await _userGames.Query()
+                .Where(ug => ug.UserId == userId)
+                .Select(ug => ug.GameId)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+
+            var available = games
+                .Where(g => !ownedGameIds.Contains(g.Id))
+                .OrderBy(_ => random.Next())
+                .ToList();
+
+            if (available.Count == 0)
+            {
+                continue;
+            }
+
+            var count = random.Next(1, Math.Min(3, available.Count) + 1);
+            var selected = available.Take(count).ToList();
+
+            foreach (var game in selected)
+            {
+                var skillIndex = random.Next(0, Enum.GetValues<GameSkillLevel>().Length);
+                var inGameName = $"{game.Name.Replace(' ', '_')}#{random.Next(1000, 9999)}";
+
+                var userGame = new UserGame
+                {
+                    UserId = userId,
+                    GameId = game.Id,
+                    InGameName = inGameName,
+                    Skill = (GameSkillLevel)skillIndex,
+                    AddedAt = DateTimeOffset.UtcNow.AddDays(-random.Next(0, 30)),
+                    CreatedBy = userId,
+                    UpdatedBy = userId
+                };
+
+                await _userGames.CreateAsync(userGame, ct).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/Repositories/Persistence/Seeding/IAppSeeder.cs
+++ b/Repositories/Persistence/Seeding/IAppSeeder.cs
@@ -1,0 +1,9 @@
+namespace Repositories.Persistence.Seeding;
+
+/// <summary>
+/// Application data seeder executed during startup.
+/// </summary>
+public interface IAppSeeder
+{
+    Task SeedAsync(CancellationToken ct = default);
+}

--- a/Services/Common/Mapping/GameMappers.cs
+++ b/Services/Common/Mapping/GameMappers.cs
@@ -1,0 +1,26 @@
+namespace Services.Common.Mapping;
+
+/// <summary>
+/// Mapping helpers for game catalog entities.
+/// </summary>
+public static class GameMappers
+{
+    public static GameDto ToGameDto(this Game game)
+    {
+        ArgumentNullException.ThrowIfNull(game);
+        return new GameDto(game.Id, game.Name);
+    }
+
+    public static UserGameDto ToUserGameDto(this UserGame userGame, string gameName)
+    {
+        ArgumentNullException.ThrowIfNull(userGame);
+
+        return new UserGameDto(
+            GameId: userGame.GameId,
+            GameName: gameName,
+            InGameName: userGame.InGameName,
+            Skill: userGame.Skill,
+            AddedAt: userGame.AddedAt
+        );
+    }
+}

--- a/Services/GlobalUsing.cs
+++ b/Services/GlobalUsing.cs
@@ -19,6 +19,7 @@ global using DTOs.Rooms;
 global using DTOs.Events;
 global using DTOs.Common;
 global using DTOs.Registrations;
+global using DTOs.Games;
 global using Repositories.Interfaces;
 global using Repositories.Persistence;
 global using Repositories.WorkSeeds.Extensions;

--- a/Services/Implementations/GameCatalogService.cs
+++ b/Services/Implementations/GameCatalogService.cs
@@ -1,0 +1,253 @@
+using Microsoft.EntityFrameworkCore;
+using StackExchange.Redis;
+using System.Text.Json;
+
+namespace Services.Implementations;
+
+/// <summary>
+/// Implementation of <see cref="IGameCatalogService"/> for managing the game catalog.
+/// </summary>
+public sealed class GameCatalogService : IGameCatalogService
+{
+    private const string GamesCacheKey = "cache:games:list:v1";
+    private static readonly TimeSpan GameCacheTtl = TimeSpan.FromMinutes(20);
+    private static readonly JsonSerializerOptions CacheSerializerOptions = new(JsonSerializerDefaults.Web);
+    private static readonly string[] AllowedSorts = ["Id", "Name", "CreatedAtUtc"];
+
+    private readonly IGenericUnitOfWork _uow;
+    private readonly IGameRepository _games;
+    private readonly IConnectionMultiplexer _redis;
+
+    public GameCatalogService(
+        IGenericUnitOfWork uow,
+        IGameRepository games,
+        IConnectionMultiplexer redis)
+    {
+        _uow = uow ?? throw new ArgumentNullException(nameof(uow));
+        _games = games ?? throw new ArgumentNullException(nameof(games));
+        _redis = redis ?? throw new ArgumentNullException(nameof(redis));
+    }
+
+    public async Task<Result<Guid>> CreateAsync(string name, CancellationToken ct = default)
+    {
+        if (!TryNormalizeName(name, out var normalized, out var error))
+        {
+            return Result<Guid>.Failure(error);
+        }
+
+        var existing = await _games.GetByNameInsensitiveAsync(normalized, ct).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            return Result<Guid>.Failure(new Error(Error.Codes.Conflict, $"Game '{normalized}' already exists."));
+        }
+
+        var result = await _uow.ExecuteTransactionAsync<Guid>(async innerCt =>
+        {
+            var entity = new Game
+            {
+                Id = Guid.NewGuid(),
+                Name = normalized
+            };
+
+            await _games.CreateAsync(entity, innerCt).ConfigureAwait(false);
+            await _uow.SaveChangesAsync(innerCt).ConfigureAwait(false);
+
+            return Result<Guid>.Success(entity.Id);
+        }, ct: ct).ConfigureAwait(false);
+
+        if (result.IsSuccess)
+        {
+            await InvalidateGameCacheAsync().ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    public async Task<Result> RenameAsync(Guid gameId, string newName, CancellationToken ct = default)
+    {
+        if (gameId == Guid.Empty)
+        {
+            return Result.Failure(new Error(Error.Codes.Validation, "Game ID is required."));
+        }
+
+        if (!TryNormalizeName(newName, out var normalized, out var error))
+        {
+            return Result.Failure(error);
+        }
+
+        var game = await _games.GetByIdAsync(gameId, ct).ConfigureAwait(false);
+        if (game is null)
+        {
+            return Result.Failure(new Error(Error.Codes.NotFound, "Game not found."));
+        }
+
+        if (!string.Equals(game.Name, normalized, StringComparison.Ordinal))
+        {
+            var conflict = await _games.GetByNameInsensitiveAsync(normalized, ct).ConfigureAwait(false);
+            if (conflict is not null && conflict.Id != gameId)
+            {
+                return Result.Failure(new Error(Error.Codes.Conflict, $"Game '{normalized}' already exists."));
+            }
+        }
+        else
+        {
+            return Result.Success();
+        }
+
+        var result = await _uow.ExecuteTransactionAsync(async innerCt =>
+        {
+            game.Name = normalized;
+            game.UpdatedAtUtc = DateTime.UtcNow;
+
+            await _games.UpdateAsync(game, innerCt).ConfigureAwait(false);
+            await _uow.SaveChangesAsync(innerCt).ConfigureAwait(false);
+            return Result.Success();
+        }, ct: ct).ConfigureAwait(false);
+
+        if (result.IsSuccess)
+        {
+            await InvalidateGameCacheAsync().ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    public async Task<Result> SoftDeleteAsync(Guid gameId, CancellationToken ct = default)
+    {
+        if (gameId == Guid.Empty)
+        {
+            return Result.Failure(new Error(Error.Codes.Validation, "Game ID is required."));
+        }
+
+        var game = await _games.GetByIdAsync(gameId, ct).ConfigureAwait(false);
+        if (game is null)
+        {
+            return Result.Failure(new Error(Error.Codes.NotFound, "Game not found."));
+        }
+
+        if (game.IsDeleted)
+        {
+            return Result.Success();
+        }
+
+        var result = await _uow.ExecuteTransactionAsync(async innerCt =>
+        {
+            game.IsDeleted = true;
+            game.DeletedAtUtc = DateTime.UtcNow;
+
+            await _games.SoftDeleteAsync(game, innerCt).ConfigureAwait(false);
+            await _uow.SaveChangesAsync(innerCt).ConfigureAwait(false);
+            return Result.Success();
+        }, ct: ct).ConfigureAwait(false);
+
+        if (result.IsSuccess)
+        {
+            await InvalidateGameCacheAsync().ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    public async Task<Result<CursorPageResult<GameDto>>> SearchAsync(string? query, CursorRequest cursor, CancellationToken ct = default)
+    {
+        var sanitizedSort = NormalizeSort(cursor.SortSafe);
+        if (!AllowedSorts.Contains(sanitizedSort, StringComparer.OrdinalIgnoreCase))
+        {
+            return Result<CursorPageResult<GameDto>>.Failure(
+                new Error(Error.Codes.Validation, $"Unsupported sort '{cursor.SortSafe}'."));
+        }
+
+        var sanitizedCursor = cursor with { Sort = sanitizedSort };
+        var search = _games.Query();
+
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            var term = query.Trim().ToLowerInvariant();
+            search = search.Where(g => g.Name.ToLower().Contains(term));
+        }
+        else
+        {
+            await EnsureGameCacheWarmAsync(ct).ConfigureAwait(false);
+        }
+
+        CursorPageResult<Game> page;
+        switch (sanitizedSort)
+        {
+            case "Name":
+                page = await search.ToCursorPageAsync(sanitizedCursor, g => g.Name, ct).ConfigureAwait(false);
+                break;
+            case "CreatedAtUtc":
+                page = await search.ToCursorPageAsync(sanitizedCursor, g => g.CreatedAtUtc, ct).ConfigureAwait(false);
+                break;
+            default:
+                page = await search.ToCursorPageAsync(sanitizedCursor, g => g.Id, ct).ConfigureAwait(false);
+                break;
+        }
+
+        var dtos = page.Items.Select(g => g.ToGameDto()).ToList();
+        var resultPage = new CursorPageResult<GameDto>(
+            Items: dtos,
+            NextCursor: page.NextCursor,
+            PrevCursor: page.PrevCursor,
+            Size: page.Size,
+            Sort: page.Sort,
+            Desc: page.Desc);
+
+        return Result<CursorPageResult<GameDto>>.Success(resultPage);
+    }
+
+    private static bool TryNormalizeName(string? name, out string normalized, out Error error)
+    {
+        normalized = string.Empty;
+        error = default!;
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            error = new Error(Error.Codes.Validation, "Game name is required.");
+            return false;
+        }
+
+        normalized = name.Trim();
+        if (normalized.Length is < 1 or > 128)
+        {
+            error = new Error(Error.Codes.Validation, "Game name must be between 1 and 128 characters.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string NormalizeSort(string sort)
+    {
+        return AllowedSorts.FirstOrDefault(s => string.Equals(s, sort, StringComparison.OrdinalIgnoreCase)) ?? "Id";
+    }
+
+    private async Task EnsureGameCacheWarmAsync(CancellationToken ct)
+    {
+        var db = _redis.GetDatabase();
+        var cached = await db.StringGetAsync(GamesCacheKey).ConfigureAwait(false);
+        if (cached.HasValue)
+        {
+            return;
+        }
+
+        await RefreshGameCacheAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task RefreshGameCacheAsync(CancellationToken ct)
+    {
+        var games = await _games.Query()
+            .OrderBy(g => g.Name)
+            .Select(g => new GameDto(g.Id, g.Name))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var payload = JsonSerializer.Serialize(games, CacheSerializerOptions);
+        await _redis.GetDatabase().StringSetAsync(GamesCacheKey, payload, GameCacheTtl).ConfigureAwait(false);
+    }
+
+    private Task InvalidateGameCacheAsync()
+    {
+        return _redis.GetDatabase().KeyDeleteAsync(GamesCacheKey);
+    }
+}

--- a/Services/Implementations/UserGameService.cs
+++ b/Services/Implementations/UserGameService.cs
@@ -1,0 +1,294 @@
+using Microsoft.EntityFrameworkCore;
+using StackExchange.Redis;
+using System.Globalization;
+using System.Text.Json;
+
+namespace Services.Implementations;
+
+/// <summary>
+/// Implementation of <see cref="IUserGameService"/> allowing users to manage their games.
+/// </summary>
+public sealed class UserGameService : IUserGameService
+{
+    private const int MaxGamesPerUser = 20;
+    private const string GamesCacheKey = "cache:games:list:v1";
+    private const string UserGamesCacheKeyPrefix = "cache:user:{0}:games";
+    private static readonly TimeSpan GameCacheTtl = TimeSpan.FromMinutes(20);
+    private static readonly TimeSpan UserGamesCacheTtl = TimeSpan.FromMinutes(5);
+    private static readonly JsonSerializerOptions CacheSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly IGenericUnitOfWork _uow;
+    private readonly IUserGameRepository _userGames;
+    private readonly IGameRepository _games;
+    private readonly IConnectionMultiplexer _redis;
+
+    public UserGameService(
+        IGenericUnitOfWork uow,
+        IUserGameRepository userGames,
+        IGameRepository games,
+        IConnectionMultiplexer redis)
+    {
+        _uow = uow ?? throw new ArgumentNullException(nameof(uow));
+        _userGames = userGames ?? throw new ArgumentNullException(nameof(userGames));
+        _games = games ?? throw new ArgumentNullException(nameof(games));
+        _redis = redis ?? throw new ArgumentNullException(nameof(redis));
+    }
+
+    public async Task<Result> AddAsync(Guid currentUserId, Guid gameId, string? inGameName, GameSkillLevel? skill, CancellationToken ct = default)
+    {
+        if (currentUserId == Guid.Empty)
+        {
+            return Result.Failure(new Error(Error.Codes.Validation, "Current user is required."));
+        }
+
+        if (gameId == Guid.Empty)
+        {
+            return Result.Failure(new Error(Error.Codes.Validation, "Game ID is required."));
+        }
+
+        if (!TryNormalizeInGameName(inGameName, out var normalizedName, out var error))
+        {
+            return Result.Failure(error);
+        }
+
+        if (!IsValidSkill(skill))
+        {
+            return Result.Failure(new Error(Error.Codes.Validation, "Skill level is invalid."));
+        }
+
+        var game = await _games.GetByIdAsync(gameId, ct).ConfigureAwait(false);
+        if (game is null || game.IsDeleted)
+        {
+            return Result.Failure(new Error(Error.Codes.NotFound, "Game not found."));
+        }
+
+        var existing = await _userGames.GetAsync(currentUserId, gameId, ct).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            return Result.Failure(new Error(Error.Codes.Conflict, "Game already added."));
+        }
+
+        var count = await _userGames.Query()
+            .Where(ug => ug.UserId == currentUserId)
+            .CountAsync(ct)
+            .ConfigureAwait(false);
+
+        if (count >= MaxGamesPerUser)
+        {
+            return Result.Failure(new Error(Error.Codes.Validation, $"Users can track at most {MaxGamesPerUser} games."));
+        }
+
+        var result = await _uow.ExecuteTransactionAsync(async innerCt =>
+        {
+            var entity = new UserGame
+            {
+                UserId = currentUserId,
+                GameId = gameId,
+                InGameName = normalizedName,
+                Skill = skill,
+                AddedAt = DateTimeOffset.UtcNow,
+                CreatedBy = currentUserId,
+                UpdatedBy = currentUserId
+            };
+
+            await _userGames.CreateAsync(entity, innerCt).ConfigureAwait(false);
+            await _uow.SaveChangesAsync(innerCt).ConfigureAwait(false);
+
+            return Result.Success();
+        }, ct: ct).ConfigureAwait(false);
+
+        if (result.IsSuccess)
+        {
+            await InvalidateUserGamesCacheAsync(currentUserId).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    public async Task<Result> UpdateAsync(Guid currentUserId, Guid gameId, string? inGameName, GameSkillLevel? skill, CancellationToken ct = default)
+    {
+        if (currentUserId == Guid.Empty)
+        {
+            return Result.Failure(new Error(Error.Codes.Validation, "Current user is required."));
+        }
+
+        if (gameId == Guid.Empty)
+        {
+            return Result.Failure(new Error(Error.Codes.Validation, "Game ID is required."));
+        }
+
+        if (!TryNormalizeInGameName(inGameName, out var normalizedName, out var error))
+        {
+            return Result.Failure(error);
+        }
+
+        if (!IsValidSkill(skill))
+        {
+            return Result.Failure(new Error(Error.Codes.Validation, "Skill level is invalid."));
+        }
+
+        var userGame = await _userGames.GetAsync(currentUserId, gameId, ct).ConfigureAwait(false);
+        if (userGame is null)
+        {
+            return Result.Failure(new Error(Error.Codes.NotFound, "User game not found."));
+        }
+
+        var result = await _uow.ExecuteTransactionAsync(async innerCt =>
+        {
+            userGame.InGameName = normalizedName;
+            userGame.Skill = skill;
+            userGame.UpdatedAtUtc = DateTime.UtcNow;
+            userGame.UpdatedBy = currentUserId;
+
+            await _userGames.UpdateAsync(userGame, innerCt).ConfigureAwait(false);
+            await _uow.SaveChangesAsync(innerCt).ConfigureAwait(false);
+            return Result.Success();
+        }, ct: ct).ConfigureAwait(false);
+
+        if (result.IsSuccess)
+        {
+            await InvalidateUserGamesCacheAsync(currentUserId).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    public async Task<Result> RemoveAsync(Guid currentUserId, Guid gameId, CancellationToken ct = default)
+    {
+        if (currentUserId == Guid.Empty)
+        {
+            return Result.Failure(new Error(Error.Codes.Validation, "Current user is required."));
+        }
+
+        if (gameId == Guid.Empty)
+        {
+            return Result.Failure(new Error(Error.Codes.Validation, "Game ID is required."));
+        }
+
+        var result = await _uow.ExecuteTransactionAsync(async innerCt =>
+        {
+            var entity = await _userGames.GetAsync(currentUserId, gameId, innerCt).ConfigureAwait(false);
+            if (entity is null)
+            {
+                return Result.Success();
+            }
+
+            await _userGames.RemoveAsync(currentUserId, gameId, innerCt).ConfigureAwait(false);
+            await _uow.SaveChangesAsync(innerCt).ConfigureAwait(false);
+            return Result.Success();
+        }, ct: ct).ConfigureAwait(false);
+
+        if (result.IsSuccess)
+        {
+            await InvalidateUserGamesCacheAsync(currentUserId).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    public async Task<Result<IReadOnlyList<UserGameDto>>> ListMineAsync(Guid currentUserId, CancellationToken ct = default)
+    {
+        if (currentUserId == Guid.Empty)
+        {
+            return Result<IReadOnlyList<UserGameDto>>.Failure(new Error(Error.Codes.Validation, "Current user is required."));
+        }
+
+        var cacheKey = string.Format(CultureInfo.InvariantCulture, UserGamesCacheKeyPrefix, currentUserId);
+        var db = _redis.GetDatabase();
+        var cached = await db.StringGetAsync(cacheKey).ConfigureAwait(false);
+        if (cached.HasValue)
+        {
+            var cachedDtos = JsonSerializer.Deserialize<List<UserGameDto>>(cached.ToString(), CacheSerializerOptions) ?? new List<UserGameDto>();
+            return Result<IReadOnlyList<UserGameDto>>.Success(cachedDtos);
+        }
+
+        var items = await _userGames.ListByUserAsync(currentUserId, ct).ConfigureAwait(false);
+        if (items.Count == 0)
+        {
+            await db.StringSetAsync(cacheKey, "[]", UserGamesCacheTtl).ConfigureAwait(false);
+            return Result<IReadOnlyList<UserGameDto>>.Success(Array.Empty<UserGameDto>());
+        }
+
+        var gameIds = items.Select(i => i.GameId).Distinct().ToList();
+        var gameNames = await GetGameNamesAsync(gameIds, ct).ConfigureAwait(false);
+
+        var dtos = items
+            .Select(item => item.ToUserGameDto(gameNames.TryGetValue(item.GameId, out var name) ? name : ""))
+            .ToList();
+
+        var payload = JsonSerializer.Serialize(dtos, CacheSerializerOptions);
+        await db.StringSetAsync(cacheKey, payload, UserGamesCacheTtl).ConfigureAwait(false);
+
+        return Result<IReadOnlyList<UserGameDto>>.Success(dtos);
+    }
+
+    private static bool TryNormalizeInGameName(string? value, out string? normalized, out Error error)
+    {
+        normalized = null;
+        error = default!;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        normalized = value.Trim();
+        if (normalized.Length is < 1 or > 64)
+        {
+            error = new Error(Error.Codes.Validation, "In-game name must be between 1 and 64 characters when provided.");
+            normalized = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsValidSkill(GameSkillLevel? skill)
+    {
+        if (!skill.HasValue)
+        {
+            return true;
+        }
+
+        return Enum.IsDefined(typeof(GameSkillLevel), skill.Value);
+    }
+
+    private async Task<Dictionary<Guid, string>> GetGameNamesAsync(IEnumerable<Guid> gameIds, CancellationToken ct)
+    {
+        var required = gameIds.Distinct().ToList();
+        if (required.Count == 0)
+        {
+            return new Dictionary<Guid, string>();
+        }
+
+        var db = _redis.GetDatabase();
+        var cached = await db.StringGetAsync(GamesCacheKey).ConfigureAwait(false);
+        Dictionary<Guid, string>? names = null;
+
+        if (cached.HasValue)
+        {
+            var cachedGames = JsonSerializer.Deserialize<List<GameDto>>(cached.ToString(), CacheSerializerOptions) ?? new List<GameDto>();
+            names = cachedGames.ToDictionary(g => g.Id, g => g.Name);
+            if (required.All(id => names.ContainsKey(id)))
+            {
+                return names;
+            }
+        }
+
+        var refreshed = await _games.Query()
+            .Select(g => new GameDto(g.Id, g.Name))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var payload = JsonSerializer.Serialize(refreshed, CacheSerializerOptions);
+        await db.StringSetAsync(GamesCacheKey, payload, GameCacheTtl).ConfigureAwait(false);
+
+        return refreshed.ToDictionary(g => g.Id, g => g.Name);
+    }
+
+    private Task InvalidateUserGamesCacheAsync(Guid userId)
+    {
+        var cacheKey = string.Format(CultureInfo.InvariantCulture, UserGamesCacheKeyPrefix, userId);
+        return _redis.GetDatabase().KeyDeleteAsync(cacheKey);
+    }
+}

--- a/Services/Interfaces/IGameCatalogService.cs
+++ b/Services/Interfaces/IGameCatalogService.cs
@@ -1,0 +1,12 @@
+namespace Services.Interfaces;
+
+/// <summary>
+/// Admin-facing catalog service for games.
+/// </summary>
+public interface IGameCatalogService
+{
+    Task<Result<Guid>> CreateAsync(string name, CancellationToken ct = default);
+    Task<Result> RenameAsync(Guid gameId, string newName, CancellationToken ct = default);
+    Task<Result> SoftDeleteAsync(Guid gameId, CancellationToken ct = default);
+    Task<Result<CursorPageResult<GameDto>>> SearchAsync(string? query, CursorRequest cursor, CancellationToken ct = default);
+}

--- a/Services/Interfaces/IUserGameService.cs
+++ b/Services/Interfaces/IUserGameService.cs
@@ -1,0 +1,12 @@
+namespace Services.Interfaces;
+
+/// <summary>
+/// User-facing service for managing personal game library.
+/// </summary>
+public interface IUserGameService
+{
+    Task<Result> AddAsync(Guid currentUserId, Guid gameId, string? inGameName, GameSkillLevel? skill, CancellationToken ct = default);
+    Task<Result> UpdateAsync(Guid currentUserId, Guid gameId, string? inGameName, GameSkillLevel? skill, CancellationToken ct = default);
+    Task<Result> RemoveAsync(Guid currentUserId, Guid gameId, CancellationToken ct = default);
+    Task<Result<IReadOnlyList<UserGameDto>>> ListMineAsync(Guid currentUserId, CancellationToken ct = default);
+}

--- a/StudentGamerHub.sln
+++ b/StudentGamerHub.sln
@@ -13,6 +13,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services", "Services\Servic
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI", "WebAPI\WebAPI.csproj", "{0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Services.Games.Tests", "Tests\Services.Games.Tests\Services.Games.Tests.csproj", "{DF83D2FD-E14A-46BA-BC75-A22E46BE6545}"
+EndProject
+
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +41,10 @@ Global
 		{0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0B3B8B8F-0DD2-4A42-B282-3FA6D91725F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF83D2FD-E14A-46BA-BC75-A22E46BE6545}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF83D2FD-E14A-46BA-BC75-A22E46BE6545}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF83D2FD-E14A-46BA-BC75-A22E46BE6545}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF83D2FD-E14A-46BA-BC75-A22E46BE6545}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/Services.Games.Tests/GamesServiceTests.cs
+++ b/Tests/Services.Games.Tests/GamesServiceTests.cs
@@ -1,0 +1,255 @@
+using BusinessObjects.Common.Results;
+using BusinessObjects;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using StackExchange.Redis;
+using System.Collections.Concurrent;
+using Xunit;
+using Repositories.Implements;
+using Repositories.Persistence;
+using Repositories.WorkSeeds.Implements;
+
+namespace Services.Games.Tests;
+
+public sealed class GamesServiceTests
+{
+    [Fact]
+    public async Task CreateAsync_ShouldReturnValidation_WhenNameEmpty()
+    {
+        await using var ctx = await GamesTestContext.CreateAsync();
+
+        var result = await ctx.CatalogService.CreateAsync(string.Empty);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Validation);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldReturnConflict_WhenNameExists()
+    {
+        await using var ctx = await GamesTestContext.CreateAsync();
+        ctx.Db.Games.Add(new Game { Id = Guid.NewGuid(), Name = "Valorant" });
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.CatalogService.CreateAsync("valorant");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Conflict);
+    }
+
+    [Fact]
+    public async Task RenameAsync_ShouldReturnConflict_WhenTargetNameExists()
+    {
+        await using var ctx = await GamesTestContext.CreateAsync();
+        var gameA = new Game { Id = Guid.NewGuid(), Name = "Valorant" };
+        var gameB = new Game { Id = Guid.NewGuid(), Name = "Apex Legends" };
+        ctx.Db.Games.AddRange(gameA, gameB);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.CatalogService.RenameAsync(gameB.Id, "Valorant");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Conflict);
+    }
+
+    [Fact]
+    public async Task AddAsync_ShouldReturnNotFound_WhenGameMissing()
+    {
+        await using var ctx = await GamesTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+
+        var result = await ctx.UserGameService.AddAsync(userId, Guid.NewGuid(), null, null);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.NotFound);
+    }
+
+    [Fact]
+    public async Task AddAsync_ShouldReturnConflict_WhenAlreadyExists()
+    {
+        await using var ctx = await GamesTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        ctx.Db.Games.Add(new Game { Id = gameId, Name = "Valorant" });
+        ctx.Db.UserGames.Add(new UserGame { UserId = userId, GameId = gameId });
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.UserGameService.AddAsync(userId, gameId, null, null);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Conflict);
+    }
+
+    [Fact]
+    public async Task AddAsync_ShouldReturnValidation_WhenLimitExceeded()
+    {
+        await using var ctx = await GamesTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+
+        for (var i = 0; i < 20; i++)
+        {
+            var game = new Game { Id = Guid.NewGuid(), Name = $"Game {i}" };
+            ctx.Db.Games.Add(game);
+            ctx.Db.UserGames.Add(new UserGame { UserId = userId, GameId = game.Id });
+        }
+        await ctx.Db.SaveChangesAsync();
+
+        var extraGameId = Guid.NewGuid();
+        ctx.Db.Games.Add(new Game { Id = extraGameId, Name = "Extra" });
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.UserGameService.AddAsync(userId, extraGameId, null, null);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Validation);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldReturnValidation_WhenInGameNameTooLong()
+    {
+        await using var ctx = await GamesTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        ctx.Db.Games.Add(new Game { Id = gameId, Name = "Valorant" });
+        ctx.Db.UserGames.Add(new UserGame { UserId = userId, GameId = gameId });
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.UserGameService.UpdateAsync(userId, gameId, new string('a', 65), null);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Validation);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_ShouldBeIdempotent()
+    {
+        await using var ctx = await GamesTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        ctx.Db.Games.Add(new Game { Id = gameId, Name = "Valorant" });
+        ctx.Db.UserGames.Add(new UserGame { UserId = userId, GameId = gameId });
+        await ctx.Db.SaveChangesAsync();
+
+        var first = await ctx.UserGameService.RemoveAsync(userId, gameId);
+        var second = await ctx.UserGameService.RemoveAsync(userId, gameId);
+
+        first.IsSuccess.Should().BeTrue();
+        second.IsSuccess.Should().BeTrue();
+    }
+
+    private sealed class GamesTestContext : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly ConcurrentDictionary<string, (RedisValue Value, DateTimeOffset? Expiration)> _cache = new();
+
+        public required AppDbContext Db { get; init; }
+        public required IGenericUnitOfWork Uow { get; init; }
+        public required GameCatalogService CatalogService { get; init; }
+        public required UserGameService UserGameService { get; init; }
+
+        private GamesTestContext(SqliteConnection connection)
+        {
+            _connection = connection;
+        }
+
+        public static async Task<GamesTestContext> CreateAsync()
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var db = new AppDbContext(options);
+            await db.Database.EnsureCreatedAsync();
+
+            var services = new ServiceCollection().BuildServiceProvider();
+            var factory = new RepositoryFactory(db, services);
+            var uow = new UnitOfWork(db, factory);
+            var gameRepo = new GameRepository(db);
+            var userGameRepo = new UserGameRepository(db);
+
+            var redis = Substitute.For<IConnectionMultiplexer>();
+            var database = Substitute.For<IDatabase>();
+            var catalogService = new GameCatalogService(uow, gameRepo, redis);
+            var userGameService = new UserGameService(uow, userGameRepo, gameRepo, redis);
+
+            var ctx = new GamesTestContext(connection)
+            {
+                Db = db,
+                Uow = uow,
+                CatalogService = catalogService,
+                UserGameService = userGameService,
+            };
+
+            ConfigureRedis(redis, database, ctx._cache);
+
+            return ctx;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await Uow.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+
+        private static void ConfigureRedis(IConnectionMultiplexer redis, IDatabase database, ConcurrentDictionary<string, (RedisValue Value, DateTimeOffset? Expiration)> cache)
+        {
+            redis.GetDatabase(Arg.Any<int>(), Arg.Any<object?>()).Returns(database);
+
+            database.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>()).Returns(callInfo =>
+            {
+                var key = callInfo.Arg<RedisKey>().ToString();
+                if (key is null)
+                {
+                    return Task.FromResult(RedisValue.Null);
+                }
+
+                if (cache.TryGetValue(key, out var entry))
+                {
+                    if (entry.Expiration is { } expiry && expiry <= DateTimeOffset.UtcNow)
+                    {
+                        cache.TryRemove(key, out _);
+                        return Task.FromResult(RedisValue.Null);
+                    }
+
+                    return Task.FromResult(entry.Value);
+                }
+
+                return Task.FromResult(RedisValue.Null);
+            });
+
+            database.StringSetAsync(Arg.Any<RedisKey>(), Arg.Any<RedisValue>(), Arg.Any<TimeSpan?>(), Arg.Any<When>(), Arg.Any<CommandFlags>())
+                .Returns(callInfo =>
+                {
+                    var key = callInfo.Arg<RedisKey>().ToString();
+                    if (key is null)
+                    {
+                        return Task.FromResult(false);
+                    }
+
+                    var value = callInfo.Arg<RedisValue>();
+                    var ttl = callInfo.Arg<TimeSpan?>();
+                    var expiration = ttl.HasValue ? DateTimeOffset.UtcNow.Add(ttl.Value) : null;
+                    cache[key] = (value, expiration);
+                    return Task.FromResult(true);
+                });
+
+            database.KeyDeleteAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>()).Returns(callInfo =>
+            {
+                var key = callInfo.Arg<RedisKey>().ToString();
+                if (key is null)
+                {
+                    return Task.FromResult(false);
+                }
+
+                return Task.FromResult(cache.TryRemove(key, out _));
+            });
+        }
+    }
+}

--- a/Tests/Services.Games.Tests/ResultExtensionsSmokeTests.cs
+++ b/Tests/Services.Games.Tests/ResultExtensionsSmokeTests.cs
@@ -1,0 +1,22 @@
+using BusinessObjects.Common;
+using BusinessObjects.Common.Results;
+using FluentAssertions;
+using Xunit;
+
+namespace Services.Games.Tests;
+
+public sealed class ResultExtensionsSmokeTests
+{
+    [Fact]
+    public async Task TryAsync_ShouldReturnFailure_WhenExceptionThrown()
+    {
+        var result = await ResultExtensions.TryAsync(async () =>
+        {
+            await Task.Delay(10);
+            throw new InvalidOperationException("boom");
+        });
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Unexpected);
+    }
+}

--- a/Tests/Services.Games.Tests/Services.Games.Tests.csproj
+++ b/Tests/Services.Games.Tests/Services.Games.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Services\Services.csproj" />
+  </ItemGroup>
+</Project>

--- a/WebAPI/Controllers/GamesController.cs
+++ b/WebAPI/Controllers/GamesController.cs
@@ -1,0 +1,100 @@
+using BusinessObjects.Common.Pagination;
+using DTOs.Games;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using WebApi.Common;
+
+namespace WebAPI.Controllers;
+
+/// <summary>
+/// Administrative endpoints for managing the game catalog.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public sealed class GamesController : ControllerBase
+{
+    private readonly IGameCatalogService _service;
+
+    public GamesController(IGameCatalogService service)
+    {
+        _service = service ?? throw new ArgumentNullException(nameof(service));
+    }
+
+    /// <summary>
+    /// Creates a new game entry in the catalog.
+    /// </summary>
+    [HttpPost]
+    [EnableRateLimiting("GamesWrite")]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    public async Task<ActionResult> Create([FromBody] GameCreateRequestDto request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var result = await _service.CreateAsync(request.Name, ct).ConfigureAwait(false);
+        return this.ToActionResult(result, id => new { id }, StatusCodes.Status201Created);
+    }
+
+    /// <summary>
+    /// Renames an existing game.
+    /// </summary>
+    [HttpPatch("{id:guid}/rename")]
+    [EnableRateLimiting("GamesWrite")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    public async Task<ActionResult> Rename(Guid id, [FromBody] GameRenameRequestDto request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var result = await _service.RenameAsync(id, request.Name, ct).ConfigureAwait(false);
+        return this.ToActionResult(result);
+    }
+
+    /// <summary>
+    /// Soft-deletes a game. Existing user associations remain but the game is hidden from public listings.
+    /// </summary>
+    [HttpDelete("{id:guid}")]
+    [EnableRateLimiting("GamesWrite")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    public async Task<ActionResult> SoftDelete(Guid id, CancellationToken ct)
+    {
+        var result = await _service.SoftDeleteAsync(id, ct).ConfigureAwait(false);
+        return this.ToActionResult(result);
+    }
+
+    /// <summary>
+    /// Searches the game catalog with cursor-based pagination.
+    /// </summary>
+    [HttpGet]
+    [AllowAnonymous]
+    [EnableRateLimiting("GamesRead")]
+    [ProducesResponseType(typeof(CursorPageResult<GameDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    public async Task<ActionResult> Search(
+        [FromQuery] string? q,
+        [FromQuery] string? cursor,
+        [FromQuery] CursorDirection direction = CursorDirection.Next,
+        [FromQuery] int size = PaginationOptions.DefaultPageSize,
+        [FromQuery] string? sort = null,
+        [FromQuery] bool desc = false,
+        CancellationToken ct = default)
+    {
+        var request = new CursorRequest(cursor, direction, size, sort, desc);
+        var result = await _service.SearchAsync(q, request, ct).ConfigureAwait(false);
+        return this.ToActionResult(result);
+    }
+}

--- a/WebAPI/Controllers/UserGamesController.cs
+++ b/WebAPI/Controllers/UserGamesController.cs
@@ -1,0 +1,113 @@
+using DTOs.Games;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using WebApi.Common;
+
+namespace WebAPI.Controllers;
+
+/// <summary>
+/// Endpoints for users to manage their personal game catalog.
+/// </summary>
+[ApiController]
+[Route("api/me/games")]
+[Authorize]
+public sealed class UserGamesController : ControllerBase
+{
+    private readonly IUserGameService _service;
+
+    public UserGamesController(IUserGameService service)
+    {
+        _service = service ?? throw new ArgumentNullException(nameof(service));
+    }
+
+    /// <summary>
+    /// Lists the games currently tracked by the authenticated user.
+    /// </summary>
+    [HttpGet]
+    [EnableRateLimiting("GamesRead")]
+    [ProducesResponseType(typeof(IReadOnlyList<UserGameDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    public async Task<ActionResult> ListMine(CancellationToken ct)
+    {
+        var userId = User.GetUserId();
+        if (!userId.HasValue)
+        {
+            return this.ToActionResult(Result.Failure(new Error(Error.Codes.Forbidden, "User identity is required.")));
+        }
+
+        var result = await _service.ListMineAsync(userId.Value, ct).ConfigureAwait(false);
+        return this.ToActionResult(result);
+    }
+
+    /// <summary>
+    /// Adds a new game association for the authenticated user.
+    /// </summary>
+    [HttpPost("{gameId:guid}")]
+    [EnableRateLimiting("GamesWrite")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    public async Task<ActionResult> Add(Guid gameId, [FromBody] UserGameUpsertRequestDto request, CancellationToken ct)
+    {
+        var userId = User.GetUserId();
+        if (!userId.HasValue)
+        {
+            return this.ToActionResult(Result.Failure(new Error(Error.Codes.Forbidden, "User identity is required.")));
+        }
+
+        ArgumentNullException.ThrowIfNull(request);
+
+        var result = await _service.AddAsync(userId.Value, gameId, request.InGameName, request.Skill, ct).ConfigureAwait(false);
+        return this.ToActionResult(result);
+    }
+
+    /// <summary>
+    /// Updates an existing user-game association.
+    /// </summary>
+    [HttpPut("{gameId:guid}")]
+    [EnableRateLimiting("GamesWrite")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    public async Task<ActionResult> Update(Guid gameId, [FromBody] UserGameUpsertRequestDto request, CancellationToken ct)
+    {
+        var userId = User.GetUserId();
+        if (!userId.HasValue)
+        {
+            return this.ToActionResult(Result.Failure(new Error(Error.Codes.Forbidden, "User identity is required.")));
+        }
+
+        ArgumentNullException.ThrowIfNull(request);
+
+        var result = await _service.UpdateAsync(userId.Value, gameId, request.InGameName, request.Skill, ct).ConfigureAwait(false);
+        return this.ToActionResult(result);
+    }
+
+    /// <summary>
+    /// Removes a game from the authenticated user's catalog.
+    /// </summary>
+    [HttpDelete("{gameId:guid}")]
+    [EnableRateLimiting("GamesWrite")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    public async Task<ActionResult> Remove(Guid gameId, CancellationToken ct)
+    {
+        var userId = User.GetUserId();
+        if (!userId.HasValue)
+        {
+            return this.ToActionResult(Result.Failure(new Error(Error.Codes.Forbidden, "User identity is required.")));
+        }
+
+        var result = await _service.RemoveAsync(userId.Value, gameId, ct).ConfigureAwait(false);
+        return this.ToActionResult(result);
+    }
+}

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -26,6 +26,36 @@ public static class ServiceCollectionExtensions
         {
             options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
 
+            options.AddPolicy("GamesWrite", httpContext =>
+            {
+                var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
+
+                return RateLimitPartition.GetTokenBucketLimiter(userKey, _ => new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = 60,
+                    TokensPerPeriod = 60,
+                    ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                });
+            });
+
+            options.AddPolicy("GamesRead", httpContext =>
+            {
+                var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
+
+                return RateLimitPartition.GetTokenBucketLimiter(userKey, _ => new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = 120,
+                    TokensPerPeriod = 120,
+                    ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                });
+            });
+
             options.AddPolicy("EventsWrite", httpContext =>
             {
                 var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();


### PR DESCRIPTION
## Summary
- add DTOs, repositories, and services to manage the game catalog and user-game links with caching and validation
- enforce database constraints via a new migration, update the DbContext configuration, and seed demo catalog data
- expose admin and user-facing Web API endpoints with rate limiting and add unit tests plus solution wiring for the new test project

## Testing
- not run (dotnet CLI unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68f04337e6c8832d9ccc434126348126