### PR TITLE
Fix escrow top-up flow and registration capacity handling

### DIFF
--- a/BusinessObjects/User.cs
+++ b/BusinessObjects/User.cs
@@ -240,6 +240,7 @@ public sealed class Transaction : AuditableEntity
 
 
 // PAYMENT INTENT
+[Index(nameof(EventId))]
 public sealed class PaymentIntent : AuditableEntity
 {
     public Guid UserId { get; set; }
@@ -247,9 +248,12 @@ public sealed class PaymentIntent : AuditableEntity
 
     public long AmountCents { get; set; }
     public PaymentPurpose Purpose { get; set; } // vd: TopUp = 0, EventTicket = 1
-    
+
     public Guid? EventRegistrationId { get; set; }
     public EventRegistration? EventRegistration { get; set; }
+
+    public Guid? EventId { get; set; }
+    public Event? Event { get; set; }
 
     public PaymentIntentStatus Status { get; set; } = PaymentIntentStatus.RequiresPayment;
     public string ClientSecret { get; set; } = default!;

--- a/DTOs/Events/EventEscrowTopUpRequestDto.cs
+++ b/DTOs/Events/EventEscrowTopUpRequestDto.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DTOs.Events;
+
+public sealed record EventEscrowTopUpRequestDto
+{
+    [Range(1, long.MaxValue, ErrorMessage = "Amount must be positive.")]
+    public long AmountCents { get; init; }
+}

--- a/DTOs/Registrations/PaymentIntentDto.cs
+++ b/DTOs/Registrations/PaymentIntentDto.cs
@@ -5,6 +5,7 @@ public sealed record PaymentIntentDto(
     long AmountCents,
     PaymentPurpose Purpose,
     Guid? EventRegistrationId,
+    Guid? EventId,
     PaymentIntentStatus Status,
     DateTime ExpiresAt,
     string ClientSecret);

--- a/Repositories/Interfaces/IPaymentIntentRepository.cs
+++ b/Repositories/Interfaces/IPaymentIntentRepository.cs
@@ -7,4 +7,5 @@ public interface IPaymentIntentRepository
     Task<PaymentIntent?> GetByProviderRefAsync(string providerRef, CancellationToken ct = default);
     Task CreateAsync(PaymentIntent pi, CancellationToken ct = default);
     Task UpdateAsync(PaymentIntent pi, CancellationToken ct = default);
+    Task<int> CountActivePendingByEventAsync(Guid eventId, DateTime nowUtc, CancellationToken ct = default);
 }

--- a/Repositories/Persistence/AppDbContext.cs
+++ b/Repositories/Persistence/AppDbContext.cs
@@ -466,8 +466,14 @@ namespace Repositories.Persistence
                  .HasForeignKey(x => x.UserId)
                  .OnDelete(DeleteBehavior.Restrict);
 
+                e.HasOne(x => x.Event)
+                 .WithMany()
+                 .HasForeignKey(x => x.EventId)
+                 .OnDelete(DeleteBehavior.SetNull);
+
                 e.HasIndex(x => x.UserId);
                 e.HasIndex(x => x.EventRegistrationId).IsUnique();
+                e.HasIndex(x => x.EventId);
 
                 e.HasCheckConstraint(
                     "chk_payment_intent_amount_positive",

--- a/Services/Implementations/PaymentReadService.cs
+++ b/Services/Implementations/PaymentReadService.cs
@@ -25,6 +25,7 @@ public sealed class PaymentReadService : IPaymentReadService
             pi.AmountCents,
             pi.Purpose,
             pi.EventRegistrationId,
+            pi.EventId,
             pi.Status,
             pi.ExpiresAt,
             pi.ClientSecret);

--- a/Services/Interfaces/IPaymentService.cs
+++ b/Services/Interfaces/IPaymentService.cs
@@ -4,6 +4,7 @@ namespace Services.Interfaces;
 
 public interface IPaymentService
 {
+    Task<Result<Guid>> CreateTopUpIntentAsync(Guid organizerId, Guid eventId, long amountCents, CancellationToken ct = default);
     Task<Result> ConfirmAsync(Guid userId, Guid paymentIntentId, CancellationToken ct = default);
     Task<Result<string>> CreateHostedCheckoutUrlAsync(Guid userId, Guid paymentIntentId, string? returnUrl, string clientIp, CancellationToken ct = default);
     Task<Result> HandleVnPayCallbackAsync(IQueryCollection query, IFormCollection? form, CancellationToken ct = default);


### PR DESCRIPTION
## Summary
- add support for linking payment intents directly to events and expose a top-up creation endpoint for organizers
- ensure payment services rely on the stored EventId when confirming top-ups and mark VNPAY transactions as gateway payments
- adjust registration capacity calculations to ignore expired pending intents

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f1e56886c8832da1dfd5121d23feeb