### PR TITLE
Implement friend search and request APIs

### DIFF
--- a/DTOs/Friends/FriendRequestItemDto.cs
+++ b/DTOs/Friends/FriendRequestItemDto.cs
@@ -1,0 +1,10 @@
+namespace DTOs.Friends;
+
+public sealed record FriendRequestItemDto(
+    Guid UserId,
+    string UserName,
+    string FullName,
+    string? AvatarUrl,
+    string? University,
+    string Status,
+    DateTime RequestedAtUtc);

--- a/DTOs/Friends/FriendRequestsOverviewDto.cs
+++ b/DTOs/Friends/FriendRequestsOverviewDto.cs
@@ -1,0 +1,5 @@
+namespace DTOs.Friends;
+
+public sealed record FriendRequestsOverviewDto(
+    IReadOnlyList<FriendRequestItemDto> Incoming,
+    IReadOnlyList<FriendRequestItemDto> Outgoing);

--- a/DTOs/Friends/UserSearchItemDto.cs
+++ b/DTOs/Friends/UserSearchItemDto.cs
@@ -1,0 +1,10 @@
+namespace DTOs.Friends;
+
+public sealed record UserSearchItemDto(
+    Guid UserId,
+    string UserName,
+    string FullName,
+    string? AvatarUrl,
+    string? University,
+    bool IsFriend,
+    bool IsPending);

--- a/Services/Application/Friends/IFriendService.cs
+++ b/Services/Application/Friends/IFriendService.cs
@@ -6,6 +6,33 @@ namespace Application.Friends;
 
 public interface IFriendService
 {
+    Task<Result<PagedResponse<UserSearchItemDto>>> SearchUsersAsync(
+        Guid currentUserId,
+        string? keyword,
+        PageRequest page,
+        CancellationToken ct = default);
+
+    Task<Result<PagedResponse<FriendRequestItemDto>>> GetIncomingRequestsAsync(
+        Guid currentUserId,
+        PageRequest page,
+        CancellationToken ct = default);
+
+    Task<Result<PagedResponse<FriendRequestItemDto>>> GetOutgoingRequestsAsync(
+        Guid currentUserId,
+        string? status,
+        PageRequest page,
+        CancellationToken ct = default);
+
+    Task<Result<FriendRequestsOverviewDto>> GetRequestsOverviewAsync(
+        Guid currentUserId,
+        int take,
+        CancellationToken ct = default);
+
+    Task<Result<PagedResponse<UserSearchItemDto>>> GetSuggestedFriendsAsync(
+        Guid currentUserId,
+        PageRequest page,
+        CancellationToken ct = default);
+
     Task<Result> InviteAsync(
         Guid requesterId,
         Guid targetUserId,

--- a/Services/Common/Mapping/UserMappers.cs
+++ b/Services/Common/Mapping/UserMappers.cs
@@ -43,6 +43,48 @@ namespace Services.Common.Mapping
             throw new InvalidOperationException("Requester must be associated with the friend link.");
         }
 
+        public static UserSearchItemDto ToUserSearchItemDto(
+            this User user,
+            bool isFriend,
+            bool isPending)
+        {
+            ArgumentNullException.ThrowIfNull(user);
+
+            return new UserSearchItemDto(
+                UserId: user.Id,
+                UserName: user.UserName ?? string.Empty,
+                FullName: user.FullName ?? string.Empty,
+                AvatarUrl: user.AvatarUrl,
+                University: user.University,
+                IsFriend: isFriend,
+                IsPending: isPending);
+        }
+
+        public static FriendRequestItemDto ToFriendRequestItemDtoFor(
+            this FriendLink link,
+            Guid currentUserId)
+        {
+            ArgumentNullException.ThrowIfNull(link);
+
+            var counterpart = link.SenderId == currentUserId
+                ? link.Recipient
+                : link.Sender;
+
+            if (counterpart is null)
+            {
+                throw new InvalidOperationException("Friend link counterpart must be loaded.");
+            }
+
+            return new FriendRequestItemDto(
+                UserId: counterpart.Id,
+                UserName: counterpart.UserName ?? string.Empty,
+                FullName: counterpart.FullName ?? string.Empty,
+                AvatarUrl: counterpart.AvatarUrl,
+                University: counterpart.University,
+                Status: link.Status.ToString(),
+                RequestedAtUtc: link.CreatedAtUtc);
+        }
+
         /// <summary>
         /// Map entity -> UserListItemDto (UTC -> VN khi hiển thị).
         /// </summary>

--- a/Services/Friends/FriendService.cs
+++ b/Services/Friends/FriendService.cs
@@ -16,15 +16,380 @@ public sealed class FriendService : IFriendService
     private readonly IGenericRepository<User, Guid> _users;
     private readonly IGenericRepository<FriendLink, Guid> _friendLinks;
     private readonly IQuestService? _quests;
+    private readonly IPresenceService? _presence;
 
     public FriendService(
         IGenericUnitOfWork uow,
-        IQuestService? quests = null)
+        IQuestService? quests = null,
+        IPresenceService? presence = null)
     {
         _uow = uow ?? throw new ArgumentNullException(nameof(uow));
         _users = _uow.GetRepository<User, Guid>();
         _friendLinks = _uow.GetRepository<FriendLink, Guid>();
         _quests = quests;
+        _presence = presence;
+    }
+
+    public async Task<Result<PagedResponse<UserSearchItemDto>>> SearchUsersAsync(
+        Guid currentUserId,
+        string? keyword,
+        PageRequest request,
+        CancellationToken ct = default)
+    {
+        if (currentUserId == Guid.Empty)
+        {
+            return Result<PagedResponse<UserSearchItemDto>>.Failure(
+                new Error(Error.Codes.Validation, "User id is required."));
+        }
+
+        var page = request.PageSafe;
+        var size = Math.Clamp(request.SizeSafe, 1, 50);
+        var sort = string.IsNullOrWhiteSpace(request.Sort) ? nameof(User.FullName) : request.Sort!;
+        var sanitized = new PageRequest(page, size, sort, request.Desc);
+
+        try
+        {
+            var baseQuery = _users
+                .GetQueryable(asNoTracking: true)
+                .Where(u => u.Id != currentUserId)
+                .ApplyKeyword(keyword);
+
+            var pagedUsers = await baseQuery
+                .ToPagedResultAsync(sanitized, ct)
+                .ConfigureAwait(false);
+
+            var userIds = pagedUsers.Items.Select(u => u.Id).ToArray();
+
+            List<FriendLink> relatedLinks = new();
+            if (userIds.Length > 0)
+            {
+                relatedLinks = await _friendLinks
+                    .GetQueryable(asNoTracking: true)
+                    .Where(link =>
+                        (link.SenderId == currentUserId && userIds.Contains(link.RecipientId)) ||
+                        (link.RecipientId == currentUserId && userIds.Contains(link.SenderId)))
+                    .ToListAsync(ct)
+                    .ConfigureAwait(false);
+            }
+
+            var items = pagedUsers.Items
+                .Select(user =>
+                {
+                    var link = relatedLinks.FirstOrDefault(l =>
+                        (l.SenderId == currentUserId && l.RecipientId == user.Id) ||
+                        (l.RecipientId == currentUserId && l.SenderId == user.Id));
+
+                    var isFriend = link?.Status == FriendStatus.Accepted;
+                    var isPending = link?.Status == FriendStatus.Pending && link.SenderId == currentUserId;
+
+                    return user.ToUserSearchItemDto(isFriend, isPending);
+                })
+                .ToList();
+
+            var response = new PagedResponse<UserSearchItemDto>(
+                items,
+                pagedUsers.Page,
+                pagedUsers.Size,
+                pagedUsers.TotalCount,
+                pagedUsers.TotalPages,
+                pagedUsers.HasPrevious,
+                pagedUsers.HasNext,
+                pagedUsers.Sort,
+                pagedUsers.Desc);
+
+            return Result<PagedResponse<UserSearchItemDto>>.Success(response);
+        }
+        catch (Exception ex)
+        {
+            return Result<PagedResponse<UserSearchItemDto>>.Failure(
+                new Error(Error.Codes.Unexpected, $"Không thể tìm kiếm người dùng: {ex.Message}"));
+        }
+    }
+
+    public async Task<Result<PagedResponse<FriendRequestItemDto>>> GetIncomingRequestsAsync(
+        Guid currentUserId,
+        PageRequest request,
+        CancellationToken ct = default)
+    {
+        if (currentUserId == Guid.Empty)
+        {
+            return Result<PagedResponse<FriendRequestItemDto>>.Failure(
+                new Error(Error.Codes.Validation, "User id is required."));
+        }
+
+        var page = request.PageSafe;
+        var size = Math.Clamp(request.SizeSafe, 1, 50);
+        var sort = string.IsNullOrWhiteSpace(request.Sort) ? nameof(FriendLink.CreatedAtUtc) : request.Sort!;
+        var sanitized = new PageRequest(page, size, sort, request.Desc);
+
+        try
+        {
+            var query = _friendLinks
+                .GetQueryable(asNoTracking: true)
+                .Include(link => link.Sender)
+                .Where(link =>
+                    link.Status == FriendStatus.Pending &&
+                    link.RecipientId == currentUserId);
+
+            var paged = await query
+                .ToPagedResultAsync(sanitized, ct)
+                .ConfigureAwait(false);
+
+            var items = paged.Items
+                .Select(link => link.ToFriendRequestItemDtoFor(currentUserId))
+                .ToList();
+
+            var response = new PagedResponse<FriendRequestItemDto>(
+                items,
+                paged.Page,
+                paged.Size,
+                paged.TotalCount,
+                paged.TotalPages,
+                paged.HasPrevious,
+                paged.HasNext,
+                paged.Sort,
+                paged.Desc);
+
+            return Result<PagedResponse<FriendRequestItemDto>>.Success(response);
+        }
+        catch (Exception ex)
+        {
+            return Result<PagedResponse<FriendRequestItemDto>>.Failure(
+                new Error(Error.Codes.Unexpected, $"Không thể lấy lời mời đến: {ex.Message}"));
+        }
+    }
+
+    public async Task<Result<PagedResponse<FriendRequestItemDto>>> GetOutgoingRequestsAsync(
+        Guid currentUserId,
+        string? status,
+        PageRequest request,
+        CancellationToken ct = default)
+    {
+        if (currentUserId == Guid.Empty)
+        {
+            return Result<PagedResponse<FriendRequestItemDto>>.Failure(
+                new Error(Error.Codes.Validation, "User id is required."));
+        }
+
+        FriendStatus? statusFilter = null;
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            if (!Enum.TryParse(status, true, out FriendStatus parsed))
+            {
+                return Result<PagedResponse<FriendRequestItemDto>>.Failure(
+                    new Error(Error.Codes.Validation, $"Trạng thái '{status}' không hợp lệ."));
+            }
+
+            statusFilter = parsed;
+        }
+
+        var page = request.PageSafe;
+        var size = Math.Clamp(request.SizeSafe, 1, 50);
+        var sort = string.IsNullOrWhiteSpace(request.Sort) ? nameof(FriendLink.CreatedAtUtc) : request.Sort!;
+        var sanitized = new PageRequest(page, size, sort, request.Desc);
+
+        try
+        {
+            var query = _friendLinks
+                .GetQueryable(asNoTracking: true)
+                .Include(link => link.Recipient)
+                .Where(link => link.SenderId == currentUserId);
+
+            if (statusFilter.HasValue)
+            {
+                query = query.Where(link => link.Status == statusFilter.Value);
+            }
+
+            var paged = await query
+                .ToPagedResultAsync(sanitized, ct)
+                .ConfigureAwait(false);
+
+            var items = paged.Items
+                .Select(link => link.ToFriendRequestItemDtoFor(currentUserId))
+                .ToList();
+
+            var response = new PagedResponse<FriendRequestItemDto>(
+                items,
+                paged.Page,
+                paged.Size,
+                paged.TotalCount,
+                paged.TotalPages,
+                paged.HasPrevious,
+                paged.HasNext,
+                paged.Sort,
+                paged.Desc);
+
+            return Result<PagedResponse<FriendRequestItemDto>>.Success(response);
+        }
+        catch (Exception ex)
+        {
+            return Result<PagedResponse<FriendRequestItemDto>>.Failure(
+                new Error(Error.Codes.Unexpected, $"Không thể lấy lời mời đã gửi: {ex.Message}"));
+        }
+    }
+
+    public async Task<Result<FriendRequestsOverviewDto>> GetRequestsOverviewAsync(
+        Guid currentUserId,
+        int take,
+        CancellationToken ct = default)
+    {
+        if (currentUserId == Guid.Empty)
+        {
+            return Result<FriendRequestsOverviewDto>.Failure(
+                new Error(Error.Codes.Validation, "User id is required."));
+        }
+
+        var limit = Math.Clamp(take <= 0 ? PaginationOptions.DefaultPageSize : take, 1, 50);
+
+        try
+        {
+            var incomingTask = _friendLinks
+                .GetQueryable(asNoTracking: true)
+                .Include(link => link.Sender)
+                .Where(link =>
+                    link.Status == FriendStatus.Pending &&
+                    link.RecipientId == currentUserId)
+                .OrderByDescending(link => link.CreatedAtUtc)
+                .Take(limit)
+                .ToListAsync(ct);
+
+            var outgoingTask = _friendLinks
+                .GetQueryable(asNoTracking: true)
+                .Include(link => link.Recipient)
+                .Where(link =>
+                    link.Status == FriendStatus.Pending &&
+                    link.SenderId == currentUserId)
+                .OrderByDescending(link => link.CreatedAtUtc)
+                .Take(limit)
+                .ToListAsync(ct);
+
+            await Task.WhenAll(incomingTask, outgoingTask).ConfigureAwait(false);
+
+            var incoming = incomingTask.Result
+                .Select(link => link.ToFriendRequestItemDtoFor(currentUserId))
+                .ToList();
+            var outgoing = outgoingTask.Result
+                .Select(link => link.ToFriendRequestItemDtoFor(currentUserId))
+                .ToList();
+
+            var dto = new FriendRequestsOverviewDto(incoming, outgoing);
+            return Result<FriendRequestsOverviewDto>.Success(dto);
+        }
+        catch (Exception ex)
+        {
+            return Result<FriendRequestsOverviewDto>.Failure(
+                new Error(Error.Codes.Unexpected, $"Không thể tổng hợp lời mời kết bạn: {ex.Message}"));
+        }
+    }
+
+    public async Task<Result<PagedResponse<UserSearchItemDto>>> GetSuggestedFriendsAsync(
+        Guid currentUserId,
+        PageRequest request,
+        CancellationToken ct = default)
+    {
+        if (currentUserId == Guid.Empty)
+        {
+            return Result<PagedResponse<UserSearchItemDto>>.Failure(
+                new Error(Error.Codes.Validation, "User id is required."));
+        }
+
+        var page = request.PageSafe;
+        var size = Math.Clamp(request.SizeSafe, 1, 20);
+        var sanitized = new PageRequest(page, size, request.Sort, request.Desc);
+
+        try
+        {
+            var currentUser = await _users
+                .GetByIdAsync(currentUserId, ct: ct)
+                .ConfigureAwait(false);
+
+            if (currentUser is null)
+            {
+                return Result<PagedResponse<UserSearchItemDto>>.Failure(
+                    new Error(Error.Codes.NotFound, "Người dùng không tồn tại."));
+            }
+
+            var relatedLinks = await _friendLinks
+                .GetQueryable(asNoTracking: true)
+                .Where(link => link.SenderId == currentUserId || link.RecipientId == currentUserId)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+
+            var excludedIds = new HashSet<Guid>
+            {
+                currentUserId
+            };
+
+            foreach (var link in relatedLinks)
+            {
+                excludedIds.Add(link.SenderId == currentUserId ? link.RecipientId : link.SenderId);
+            }
+
+            var currentFriendIds = relatedLinks
+                .Where(link => link.Status == FriendStatus.Accepted)
+                .Select(link => link.SenderId == currentUserId ? link.RecipientId : link.SenderId)
+                .Distinct()
+                .ToList();
+
+            var baseCandidates = _users
+                .GetQueryable(asNoTracking: true)
+                .Where(u => !excludedIds.Contains(u.Id));
+
+            var acceptedLinks = _friendLinks
+                .GetQueryable(asNoTracking: true)
+                .Where(link => link.Status == FriendStatus.Accepted);
+
+            var query = baseCandidates
+                .Select(u => new
+                {
+                    User = u,
+                    MutualCount = acceptedLinks.Count(link =>
+                        (link.SenderId == u.Id && currentFriendIds.Contains(link.RecipientId)) ||
+                        (link.RecipientId == u.Id && currentFriendIds.Contains(link.SenderId))),
+                    SameUniversity = !string.IsNullOrWhiteSpace(u.University) &&
+                        !string.IsNullOrWhiteSpace(currentUser.University) &&
+                        u.University == currentUser.University
+                });
+
+            var ordered = query
+                .OrderByDescending(x => x.MutualCount)
+                .ThenByDescending(x => x.SameUniversity)
+                .ThenBy(x => x.User.FullName);
+
+            var total = await ordered.CountAsync(ct).ConfigureAwait(false);
+            var totalPages = (int)Math.Ceiling(total / (double)size);
+            var hasPrevious = page > 1;
+            var hasNext = page < totalPages;
+
+            var items = await ordered
+                .Skip((page - 1) * size)
+                .Take(size)
+                .Select(x => x.User)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+
+            var resultItems = items
+                .Select(u => u.ToUserSearchItemDto(isFriend: false, isPending: false))
+                .ToList();
+
+            var response = new PagedResponse<UserSearchItemDto>(
+                resultItems,
+                page,
+                size,
+                total,
+                totalPages,
+                hasPrevious,
+                hasNext,
+                sanitized.SortSafe,
+                sanitized.Desc);
+
+            return Result<PagedResponse<UserSearchItemDto>>.Success(response);
+        }
+        catch (Exception ex)
+        {
+            return Result<PagedResponse<UserSearchItemDto>>.Failure(
+                new Error(Error.Codes.Unexpected, $"Không thể gợi ý bạn bè: {ex.Message}"));
+        }
     }
 
     public Task<Result> InviteAsync(Guid requesterId, Guid targetUserId, CancellationToken ct = default)
@@ -242,11 +607,17 @@ public sealed class FriendService : IFriendService
                 new Error(Error.Codes.Validation, "Requester id is required."));
         }
 
-        if (filter != FriendsFilter.All)
+        if (filter != FriendsFilter.All && filter != FriendsFilter.Online)
         {
             var filterName = filter.ToString().ToLowerInvariant();
             return Result<CursorPageResult<FriendDto>>.Failure(
                 new Error(Error.Codes.Validation, $"Filter '{filterName}' is not supported."));
+        }
+
+        if (filter == FriendsFilter.Online && _presence is null)
+        {
+            return Result<CursorPageResult<FriendDto>>.Failure(
+                new Error(Error.Codes.Unexpected, "Presence service is not configured."));
         }
 
         try
@@ -266,6 +637,32 @@ public sealed class FriendService : IFriendService
             var items = result.Items
                 .Select(link => link.ToFriendDtoFor(requesterId))
                 .ToList();
+
+            if (filter == FriendsFilter.Online && _presence is not null && items.Count > 0)
+            {
+                var onlineResult = await _presence
+                    .BatchIsOnlineAsync(items.Select(i => i.User.Id).ToArray(), ct)
+                    .ConfigureAwait(false);
+
+                if (!onlineResult.IsSuccess)
+                {
+                    return Result<CursorPageResult<FriendDto>>.Failure(onlineResult.Error);
+                }
+
+                var onlineItems = items
+                    .Where(item => onlineResult.Value.TryGetValue(item.User.Id, out var online) && online)
+                    .ToList();
+
+                var onlinePaged = new CursorPageResult<FriendDto>(
+                    onlineItems,
+                    result.NextCursor,
+                    result.PrevCursor,
+                    result.Size,
+                    result.Sort,
+                    result.Desc);
+
+                return Result<CursorPageResult<FriendDto>>.Success(onlinePaged);
+            }
 
             var pagedResult = new CursorPageResult<FriendDto>(
                 Items: items,

--- a/WebAPI/Controllers/FriendsController.cs
+++ b/WebAPI/Controllers/FriendsController.cs
@@ -11,11 +11,97 @@ namespace WebAPI.Controllers
     [Authorize]
     public sealed class FriendsController : ControllerBase
     {
+        private const string PageQueryKey = "page";
+
         private readonly IFriendService _svc;
 
         public FriendsController(IFriendService svc)
         {
             _svc = svc ?? throw new ArgumentNullException(nameof(svc));
+        }
+
+        [HttpGet("search")]
+        [EnableRateLimiting("ReadsLight")]
+        [ProducesResponseType(typeof(PagedResponse<UserSearchItemDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult> Search(
+            [FromQuery(Name = "q")] string? keyword,
+            [FromQuery] PageRequest request,
+            CancellationToken ct)
+        {
+            var currentUserId = User.GetUserId();
+            if (!currentUserId.HasValue)
+            {
+                var failure = Result<PagedResponse<UserSearchItemDto>>.Failure(
+                    new Error(Error.Codes.Unauthorized, "User identity is required."));
+                return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
+            }
+
+            var result = await _svc
+                .SearchUsersAsync(currentUserId.Value, keyword, request, ct)
+                .ConfigureAwait(false);
+
+            return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+        }
+
+        [HttpGet("requests/incoming")]
+        [EnableRateLimiting("ReadsLight")]
+        [ProducesResponseType(typeof(PagedResponse<FriendRequestItemDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult> GetIncomingRequests([FromQuery] PageRequest request, CancellationToken ct)
+        {
+            var currentUserId = User.GetUserId();
+            if (!currentUserId.HasValue)
+            {
+                var failure = Result<PagedResponse<FriendRequestItemDto>>.Failure(
+                    new Error(Error.Codes.Unauthorized, "User identity is required."));
+                return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
+            }
+
+            var result = await _svc
+                .GetIncomingRequestsAsync(currentUserId.Value, request, ct)
+                .ConfigureAwait(false);
+
+            return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+        }
+
+        [HttpGet("requests/outgoing")]
+        [EnableRateLimiting("ReadsLight")]
+        [ProducesResponseType(typeof(PagedResponse<FriendRequestItemDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult> GetOutgoingRequests(
+            [FromQuery] string? status,
+            [FromQuery] PageRequest request,
+            CancellationToken ct)
+        {
+            var currentUserId = User.GetUserId();
+            if (!currentUserId.HasValue)
+            {
+                var failure = Result<PagedResponse<FriendRequestItemDto>>.Failure(
+                    new Error(Error.Codes.Unauthorized, "User identity is required."));
+                return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
+            }
+
+            var result = await _svc
+                .GetOutgoingRequestsAsync(currentUserId.Value, status, request, ct)
+                .ConfigureAwait(false);
+
+            return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
         }
 
         [HttpPost("{userId:guid}/invite")]
@@ -111,7 +197,10 @@ namespace WebAPI.Controllers
         }
 
         [HttpGet]
+        [EnableRateLimiting("ReadsLight")]
         [ProducesResponseType(typeof(CursorPageResult<FriendDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(FriendRequestsOverviewDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(PagedResponse<UserSearchItemDto>), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
@@ -138,8 +227,55 @@ namespace WebAPI.Controllers
                 return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
             }
 
-            var result = await _svc.ListAsync(currentUserId.Value, parsedFilter, request, ct).ConfigureAwait(false);
-            return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+            switch (parsedFilter)
+            {
+                case FriendsFilter.All:
+                case FriendsFilter.Online:
+                {
+                    var result = await _svc
+                        .ListAsync(currentUserId.Value, parsedFilter, request, ct)
+                        .ConfigureAwait(false);
+                    return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+                }
+
+                case FriendsFilter.Requests:
+                {
+                    var take = Math.Clamp(request.SizeSafe, 1, 50);
+                    var result = await _svc
+                        .GetRequestsOverviewAsync(currentUserId.Value, take, ct)
+                        .ConfigureAwait(false);
+                    return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+                }
+
+                case FriendsFilter.Suggested:
+                {
+                    var pageNumber = 1;
+                    if (Request.Query.TryGetValue(PageQueryKey, out var rawPage) &&
+                        int.TryParse(rawPage, out var parsedPage) && parsedPage > 0)
+                    {
+                        pageNumber = parsedPage;
+                    }
+
+                    var pageRequest = new PageRequest(
+                        page: pageNumber,
+                        size: Math.Clamp(request.SizeSafe, 1, 20),
+                        sort: request.Sort,
+                        desc: request.Desc);
+
+                    var result = await _svc
+                        .GetSuggestedFriendsAsync(currentUserId.Value, pageRequest, ct)
+                        .ConfigureAwait(false);
+                    return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+                }
+
+                default:
+                {
+                    var filterName = parsedFilter.ToString().ToLowerInvariant();
+                    var failure = Result<CursorPageResult<FriendDto>>.Failure(
+                        new Error(Error.Codes.Validation, $"Filter '{filterName}' is not supported."));
+                    return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add DTOs and mappings to represent friend search results and pending requests
- extend the friend service with search, request, suggestion, and online list capabilities
- expose search and request endpoints in FriendsController and broaden filter handling

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f1f50b0554832d8ff10a36aed68d10