### PR TITLE
Add realtime chat QA harness and load testing scripts

### DIFF
--- a/tests/realtime/README.md
+++ b/tests/realtime/README.md
@@ -1,0 +1,106 @@
+# Realtime Chat QA Harness
+
+This directory contains automated smoke/functional/resilience/load checks for the StudentGamerHub realtime chat stack (`WebAPI/Hubs/ChatHub.cs`, `Services/Implementations/ChatHistoryService.cs`, `Services/Presence/PresenceService.cs`).
+
+## Prerequisites
+1. Redis running locally (`redis://localhost:6379`) or provide `REDIS` env variable.
+2. StudentGamerHub backend running in Development (`dotnet run --project WebAPI`). Default URLs come from `WebAPI/Properties/launchSettings.json` (`https://localhost:7227`).
+3. Node.js ≥ 18.
+4. Install dependencies once:
+   ```bash
+   npm install @microsoft/signalr cross-fetch ws ioredis strip-json-comments
+   # Optional tooling
+   npm install --save-dev k6
+   ```
+5. Export any overrides as needed:
+   ```bash
+   export BASE_URL=https://localhost:7227
+   export HUB_URL=https://localhost:7227/ws/chat
+   export PRESENCE_HUB_URL=https://localhost:7227/ws/presence
+   export REDIS=redis://localhost:6379
+   export USER_A_EMAIL=realtime-a@studentgamerhub.local
+   export USER_B_EMAIL=realtime-b@studentgamerhub.local
+   export USER_A_PASSWORD=Password123!
+   export USER_B_PASSWORD=Password123!
+   export ROOM_ID=<existing-room-guid>   # optional; harness will auto-create if missing
+   ```
+
+## Running the Suites
+| Scenario | Command |
+| --- | --- |
+| Smoke DM check | `node tests/realtime/hub-smoke.js` |
+| Room broadcast | `node tests/realtime/hub-room.js` |
+| History retention | `node tests/realtime/hub-history.js` |
+| Rate limiting | `node tests/realtime/hub-ratelimit.js` |
+| Presence TTL | `node tests/realtime/hub-presence.js` |
+| Reconnect recovery | `node tests/realtime/hub-reconnect.js` |
+| k6 broadcast load | `k6 run tests/realtime/k6-room-broadcast.js` |
+| Aggregate report | `node tests/realtime/make-report.js` |
+
+All scripts emit JSONL logs in `tests/realtime/logs/` with the structure `{timestamp, case, step, result, latencyMs, details}`.
+
+## Test Users & Rooms
+- Harness auto-registers users A/B via `POST /api/auth/user-register` if they do not exist, then logs in via `POST /api/auth/login` and caches the `accessToken` for SignalR connections.
+- Room scenarios call:
+  1. `GET /api/communities?size=1` (fallback to `POST /api/communities`).
+  2. `POST /api/clubs` to create a club.
+  3. `POST /api/rooms` to create an open room.
+  4. `POST /api/rooms/{id}/join` for member enrollment.
+
+Provide `ROOM_ID` to reuse an existing room and skip provisioning.
+
+For the k6 scenario, export a fresh access token (valid for ~2 hours):
+```bash
+ACCESS_TOKEN=$(curl -sk -X POST "$BASE_URL/api/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"userNameOrEmail\":\"$USER_A_EMAIL\",\"password\":\"$USER_A_PASSWORD\"}" | jq -r '.accessToken')
+export ACCESS_TOKEN
+```
+
+## Environment Variables
+| Name | Default | Description |
+| --- | --- | --- |
+| `BASE_URL` | Auto-read from launch settings | REST API base URL |
+| `HUB_URL` | `${BASE_URL}/ws/chat` | Chat hub URL |
+| `PRESENCE_HUB_URL` | `${BASE_URL}/ws/presence` | Presence hub URL |
+| `REDIS` | `redis://localhost:6379` | Redis connection string |
+| `USER_A_*`, `USER_B_*` | Predefined test users | Override credentials/metadata |
+| `ROOM_ID` | _null_ | Existing room to reuse |
+| `RL_TOTAL` | `40` | Total messages for rate limit harness |
+| `ROOM_CLONES` | `2` | Additional member connections in room broadcast |
+| `MESSAGE_INTERVAL_MS` | `1000` (k6) | Frequency of load-test sends |
+| `VUS`, `HOLD_DURATION` | `50`, `1m` | k6 load configuration |
+| `ACCESS_TOKEN` | — | Required by k6 load test |
+
+## Redis Verification
+Use `redis-cli` to inspect keys:
+```bash
+redis-cli -u ${REDIS:-redis://localhost:6379}
+> KEYS chat:dm:* chat:room:*
+> TTL chat:dm:{pairMin}_{pairMax}
+> XLEN chat:room:{roomId}
+> TTL presence:{userId}
+```
+_Important: do **not** call `FLUSHALL` on shared environments._
+
+## Report Generation
+Run `node tests/realtime/make-report.js` after executing tests. The script consumes all JSON logs and updates `tests/realtime/REPORT.md` with:
+- Pass/fail summary per case.
+- Latency P50/P95/P99 and ASCII histograms.
+- Redis TTL samples.
+- Presence timeline tables.
+- Fix suggestions for failing cases.
+
+## Troubleshooting
+- **401 Unauthorized**: Ensure the backend is running with HTTPS and the login credentials are valid. Override via `USER_A_EMAIL`/`USER_A_PASSWORD`.
+- **TLS issues**: Node may need `NODE_TLS_REJECT_UNAUTHORIZED=0` for self-signed dev certs.
+- **Redis connection refused**: Update `REDIS` env to point at accessible instance.
+- **k6 handshake failures**: Verify `ACCESS_TOKEN` is valid and the user is approved in the target room (`POST /api/rooms/{id}/join`).
+
+## Related Source References
+- Chat Hub implementation: `WebAPI/Hubs/ChatHub.cs`
+- History service: `Services/Implementations/ChatHistoryService.cs`
+- Chat options: `Services/Configuration/ChatOptions.cs`
+- Presence hub: `WebAPI/Hubs/PresenceHub.cs`
+- Presence options: `Services/Presence/PresenceOptions.cs`
+- Abuse report API: `WebAPI/Controllers/AbuseController.cs`

--- a/tests/realtime/REPORT.md
+++ b/tests/realtime/REPORT.md
@@ -1,0 +1,23 @@
+# Realtime Chat Regression Report
+
+_Run `node tests/realtime/make-report.js` after executing the harness scripts to populate this report with live data._
+
+## Summary
+
+_No test executions recorded yet._
+
+## Latency Distributions
+
+_No latency samples available. Run the harness to capture metrics._
+
+## Redis Verification
+
+_Run the functional suites to collect Redis TTL and key evidence. Outputs will appear here automatically after generating the report._
+
+## Presence Timeline
+
+_Execute `node tests/realtime/hub-presence.js` to populate presence transitions._
+
+## Fix Suggestions
+
+_All clear. Once the report is regenerated, this section will list remediation guidance for failed scenarios._

--- a/tests/realtime/TEST_PLAN.md
+++ b/tests/realtime/TEST_PLAN.md
@@ -1,0 +1,88 @@
+# StudentGamerHub Realtime Chat Test Plan
+
+## Scope & Architecture References
+- **Hub**: `WebAPI/Hubs/ChatHub.cs` exposes `SendDm`, `SendToRoom`, `LoadHistory`, `JoinChannels` with rate limiting and Redis-backed history (`Services/Implementations/ChatHistoryService.cs`).
+- **Presence Hub**: `WebAPI/Hubs/PresenceHub.cs` stores heartbeats in Redis with TTL defined in `Services/Presence/PresenceOptions.cs`.
+- **Rate Limiting**: Configured via `ChatOptions` (`HistoryMax=200`, `HistoryTtlHours=48`, `RateLimitMaxMessages=30`, `RateLimitWindowSeconds=30`).
+- **Redis Keys**: DM -> `chat:dm:{pairMin}_{pairMax}`, Room -> `chat:room:{roomId}`, Presence -> `presence:{userId}`.
+
+## Test Levels Overview
+
+### Smoke Suite (1–2 Clients)
+| ID | Objective | Preconditions | Steps | Expected Result | Metrics / Logs |
+| --- | --- | --- | --- | --- | --- |
+| SMK-1 | Validate DM delivery via SignalR (`SendDm`) | Redis reachable; two authenticated users (A/B) | 1. Connect A & B to `/ws/chat`.<br>2. Invoke `JoinChannels` for `dm:{pair}`.<br>3. A sends single message to B. | Both clients receive identical payload with same `Id` and chronological `SentAt`. No duplicates. | JSON log with round-trip latency sample, ordering check, duplicates check, DM key name. |
+| SMK-2 | Verify authenticated connection requirement | Users created; test token revoked/empty | 1. Attempt hub connection without Bearer token.<br>2. Observe connection failure. | Unauthorized connection rejected (HTTP 401 / HubException). | Smoke harness logs `FAIL` with error, recorded in checklist for security gate. |
+
+### Functional Suite (DM / Room / History / Presence / Rate Limit / Security)
+| ID | Objective | Preconditions | Steps | Expected Result | Metrics / Logs |
+| --- | --- | --- | --- | --- | --- |
+| FUN-DM-1 | Validate DM fan-out & ordering under `SendDm` | Users A/B registered; Redis running | Re-use SMK-1 harness but send burst of 5 messages alternating A/B. | Messages delivered in send order; each `ChatMessageDto` has monotonic `SentAt`. | Round-trip latencies (P50/P95), ordering validation, duplicate detection. |
+| FUN-RM-1 | Validate room broadcast via `SendToRoom` | Host user joined/created room; N members connected | 1. Host + members join `room:{roomId}`.<br>2. Host sends broadcast.<br>3. Verify all participants receive payload. | 100% participants receive with consistent `RoomId`. | Latency per receiver, broadcast success ratio. |
+| FUN-HIST-1 | Enforce `HistoryMax` trim via `LoadHistory` | Redis seeded with >200 entries in channel | 1. Seed 220 messages using Redis Streams List.<br>2. Call `LoadHistory(channel, null, 500)`.<br>3. Request incremental history with `afterId`. | Response capped at 200; `NextAfterId` provided; new messages retrievable via `afterId`. | JSON log: returned count, TTL, XLEN, tail comparison, `NextAfterId` validation. |
+| FUN-HIST-2 | Validate TTL expiry (48h) configuration | DM channel seeded; TTL measurement window | 1. Query Redis `TTL` for `chat:dm:*`.<br>2. Confirm TTL ~ 172800 seconds after operations. | TTL within ±5% of 48h. | Redis TTL sample in log + CLI instructions. |
+| FUN-RL-1 | Verify per-connection rate limiting (30 msg/30s) | Single connection; DM target prepared | 1. Send 40 `SendDm` invocations within <30s.<br>2. Count accepted vs rejected. | First 30 succeed; subsequent 10 throw `HubException("rate_limited")`; connection remains usable. | JSON log counts, error codes, latency of accepted requests. |
+| FUN-PR-1 | Presence heartbeat expiry | Presence hub reachable; Redis running | 1. Connect & invoke `Heartbeat` once.<br>2. Wait `HeartbeatSeconds` (30s).<br>3. After `TtlSeconds+grace`, confirm `presence:{user}` removed. | Presence transitions Online → Away → Offline, TTL cleared. | Presence state table, TTL logs, last seen timestamp. |
+| FUN-SEC-1 | Room authorization enforcement | User not a member of specific room | 1. Attempt `SendToRoom` without joining room.<br>2. Expect rejection (HubException). | Unauthorized access denied; log error. | Functional harness logs security failure for manual follow-up. |
+| FUN-SEC-2 | Payload validation (empty/oversized text) | Valid connection | 1. Invoke `SendDm` with empty string.<br>2. Invoke with >2000 char string. | Hub returns `HubException` with validation message (from `ChatHistoryService.SanitizeText`). | Error logs stored with case `validation`. |
+| FUN-ABUSE-1 | Abuse report REST flow (`POST /api/abuse/report`) | Access token for reporter; message metadata | 1. Capture offending message meta via harness.<br>2. Call REST endpoint with `AbuseReportRequest` payload. | API returns 200 with bug report id; JSON log includes request/response snippet. | Postman & harness logs, ensures compliance. |
+
+### Resilience / Load Suite (Network Faults, Reconnect, Burst Users)
+| ID | Objective | Preconditions | Steps | Expected Result | Metrics / Logs |
+| --- | --- | --- | --- | --- | --- |
+| RES-REC-1 | Auto-reconnect + history recovery | Two clients in DM; hub auto-reconnect configured | 1. Drop client A transport.<br>2. Client B sends message during outage.<br>3. Verify A reconnects automatically.<br>4. Invoke `LoadHistory` to recover offline message. | Reconnect <10s; offline message retrieved once; no duplicates. | Log reconnection latency, recovered message ids. |
+| RES-NET-1 | Simulate transient hub downtime | Run harness while temporarily stopping BE (manual). | Manual step to observe client exponential backoff. | Clients should retry per `withAutomaticReconnect` policy; logs show retries. | Documented in checklist (manual). |
+| RES-LOAD-1 | Broadcast under 50–200 virtual users | k6 script running `tests/realtime/k6-room-broadcast.js` with configured VUs and RPS. | 1. Acquire access token for load user(s).<br>2. Run `k6 run ...` at 50→200 VUs ramp.<br>3. Measure P50/P95 latency, error rate, dropped frames. | P95 < 350ms; error rate <0.5%; no dropped broadcasts. | k6 summary exported + appended to report. |
+| RES-REDIS-1 | Redis eviction behaviour under burst history writes | Use `hub-history.js` seeding multiple channels simultaneously. | Keys remain capped at 200 entries; TTL maintained. | Redis CLI sample verifying `XLEN`, `TTL`. | Logged sample commands. |
+
+## Execution Checklist
+| Suite | Script / Action | Status | Notes |
+| --- | --- | --- | --- |
+| Smoke | `node tests/realtime/hub-smoke.js` | ☐ | Validates DM pipeline, logs round-trip latency. |
+| Functional | `node tests/realtime/hub-room.js` | ☐ | Broadcast + membership verification. |
+| Functional | `node tests/realtime/hub-history.js` | ☐ | History cap/TTL/pagination. |
+| Functional | `node tests/realtime/hub-ratelimit.js` | ☐ | Rate limiter enforcement. |
+| Functional | `node tests/realtime/hub-presence.js` | ☐ | Presence TTL lifecycle. |
+| Functional | Security checks (unauth/invalid payload) | ☐ | Manual via harness toggles or Postman. |
+| Functional | Abuse report API (`tests/realtime/postman_collection.json`) | ☐ | Ensure audit trail creation. |
+| Resilience | `node tests/realtime/hub-reconnect.js` | ☐ | Reconnect & recovery. |
+| Load | `k6 run tests/realtime/k6-room-broadcast.js` | ☐ | 50–200 VUs broadcast soak. |
+| Reporting | `node tests/realtime/make-report.js` | ☐ | Aggregate logs → `REPORT.md`. |
+
+## Metrics & Evidence Collection
+- **JSON Logs**: All harness scripts emit JSONL entries (`{timestamp, case, step, result, latencyMs, details}`) saved in `tests/realtime/logs/`.
+- **Latency Percentiles**: Captured per-case as P50/P95/P99 via `make-report.js` (ASCII charts).
+- **Redis Evidence**: Scripts log TTL (`TTL`, `XLEN`) and keys; manual Redis CLI guidance provided in README.
+- **Security Assertions**: Hub exceptions for unauthorized/payload failures logged with `result=FAIL` to highlight enforcement.
+- **Rate Limit Metrics**: Accepted vs rejected counts, error codes extracted in `hub-ratelimit.js` and aggregated into `REPORT.md`.
+- **Presence States**: `hub-presence.js` logs state transitions and `lastseen` snapshot.
+
+## Acceptance Gates
+- Smoke & Functional suites must report **PASS**.
+- DM P95 latency < 250 ms, Room broadcast P95 < 350 ms @ 50 VUs.
+- k6 error rate < 0.5% during 1-minute steady state.
+- Presence TTL expiry within ±10 s of configured `TtlSeconds`.
+- History endpoints return ≤200 messages in correct order with accurate `NextAfterId`.
+
+## Redis Verification Commands (Manual Reference)
+```bash
+redis-cli -u ${REDIS:-redis://localhost:6379}
+> KEYS chat:dm:* chat:room:*
+> TTL chat:dm:{pairMin}_{pairMax}
+> XLEN chat:room:{roomId}
+```
+_Avoid `FLUSHALL` in shared environments._
+
+## Security Test Notes
+- **Unauthenticated Connection**: Attempt SignalR connection without token → expect HTTP 401.
+- **Room Membership Enforcement**: Skip `JoinChannels` then invoke `SendToRoom` → expect `HubException("Unauthorized access to DM channel.")` or validation error depending on target.
+- **Payload Validation**: Empty or >2000 char text should trigger `ArgumentException` from `ChatHistoryService.SanitizeText` surfaced as HubException.
+- **Abuse Report**: Use `POST /api/abuse/report` with `AbuseReportRequest` containing message snapshot; expect 200 and bug report ID.
+
+## Environment Preparation
+- Redis connection: `${REDIS}` (defaults to `redis://localhost:6379`).
+- Backend base URL auto-detected via `launchSettings.json` (defaults `https://localhost:7227`).
+- Hub URLs: Chat `${HUB_URL:-${BASE_URL}/ws/chat}`, Presence `${PRESENCE_HUB_URL:-${BASE_URL}/ws/presence}`.
+- Test users A/B auto-provisioned via `/api/auth/user-register` if absent. Override credentials with `USER_A_EMAIL`, `USER_B_EMAIL`, etc.
+- Rooms auto-seeded via REST (`/api/communities`, `/api/clubs`, `/api/rooms`). Provide `ROOM_ID` env to reuse existing room.
+

--- a/tests/realtime/hub-history.js
+++ b/tests/realtime/hub-history.js
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+const { resolveConfig } = require('./utils/config');
+const { JsonLogger } = require('./utils/logger');
+const { ensureUser } = require('./utils/http');
+const { buildConnection, prepareEnvironment } = require('./utils/signalr');
+const { createRedisClient } = require('./utils/redis');
+const { getField } = require('./utils/accessors');
+const { randomUUID } = require('crypto');
+
+(async () => {
+  const config = resolveConfig();
+  prepareEnvironment();
+  const logger = new JsonLogger('hub-history', config.logDir);
+  const redis = createRedisClient(config.redisUrl);
+
+  try {
+    await redis.connect();
+    logger.log('setup.config', 'INFO', { hubUrl: config.hubUrl, redis: config.redisUrl, historyMax: config.chat.historyMax });
+
+    const userA = await ensureUser(config.baseUrl, config.users.A, logger);
+    const userB = await ensureUser(config.baseUrl, config.users.B, logger);
+
+    const pair = [userA.user.id, userB.user.id].sort();
+    const channel = `dm:${pair[0]}_${pair[1]}`;
+    const key = `chat:${channel}`;
+
+    logger.log('setup.channel', 'INFO', { channel, key });
+
+    const seedCount = config.chat.historyMax + 20;
+    const texts = [];
+    let useStream = true;
+    for (let i = 0; i < seedCount; i += 1) {
+      const text = `history-${i}-${randomUUID()}`;
+      texts.push(text);
+      const now = Date.now().toString();
+      if (useStream) {
+        try {
+          await redis.xadd(key, 'MAXLEN', '~', config.chat.historyMax, '*', 'fromUserId', userA.user.id, 'toUserId', userB.user.id, 'roomId', '', 'text', text, 'ts', now, 'channel', channel);
+        } catch (streamErr) {
+          useStream = false;
+          await redis.rpush(key, JSON.stringify({
+            id: `${now}-${randomUUID()}`,
+            fromUserId: userA.user.id,
+            toUserId: userB.user.id,
+            roomId: '',
+            text,
+            ts: Number(now),
+            channel
+          }));
+          await redis.ltrim(key, -config.chat.historyMax, -1);
+        }
+      } else {
+        await redis.rpush(key, JSON.stringify({
+          id: `${now}-${randomUUID()}`,
+          fromUserId: userA.user.id,
+          toUserId: userB.user.id,
+          roomId: '',
+          text,
+          ts: Number(now),
+          channel
+        }));
+        await redis.ltrim(key, -config.chat.historyMax, -1);
+      }
+    }
+    await redis.expire(key, config.chat.historyTtlHours * 3600);
+    logger.log('setup.seed', 'PASS', { inserted: seedCount });
+
+    const connection = buildConnection(config.hubUrl, userA.token, logger, 'history');
+    connection.on('history', (payload) => {
+      const items = getField(payload, 'items');
+      const nextAfterId = getField(payload, 'nextAfterId');
+      logger.log('history.receive', 'INFO', { items: items?.length, nextAfterId });
+    });
+
+    await connection.start();
+    logger.log('signalr.connected', 'PASS', { connectionId: connection.connectionId });
+
+    await connection.invoke('JoinChannels', [channel]);
+
+    // Attach promise before invoking history to avoid race
+    const historyPromise = new Promise((resolve) => {
+      const handler = (payload) => {
+        connection.off('history', handler);
+        resolve(payload);
+      };
+      connection.on('history', handler);
+    });
+
+    await connection.invoke('LoadHistory', channel, null, config.chat.historyMax + 50);
+    logger.log('history.invoke', 'PASS', { requested: config.chat.historyMax + 50 });
+    const history = await Promise.race([
+      historyPromise,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout waiting for history payload')), 5000))
+    ]);
+
+    if (!history) {
+      throw new Error('History payload missing');
+    }
+
+    const historyItems = getField(history, 'items') || [];
+    const count = Array.isArray(historyItems) ? historyItems.length : 0;
+    if (count > config.chat.historyMax) {
+      logger.log('validation.size', 'FAIL', { count, max: config.chat.historyMax });
+      throw new Error(`History exceeded limit ${config.chat.historyMax}`);
+    }
+    logger.log('validation.size', 'PASS', { count, max: config.chat.historyMax });
+
+    const tailTexts = texts.slice(-count);
+    const historyTexts = historyItems.map(item => getField(item, 'text'));
+    const mismatch = tailTexts.some((text, idx) => text !== historyTexts[idx]);
+    if (mismatch) {
+      logger.log('validation.tail', 'FAIL', { expectedTail: tailTexts.slice(0, 5), actualTail: historyTexts.slice(0, 5) });
+      throw new Error('History does not match seeded tail');
+    }
+    logger.log('validation.tail', 'PASS', { matched: count });
+
+    const nextAfterId = getField(history, 'nextAfterId');
+    if (!nextAfterId) {
+      logger.log('validation.nextAfterId', 'FAIL', { message: 'Expected nextAfterId for pagination' });
+      throw new Error('Missing nextAfterId');
+    }
+    logger.log('validation.nextAfterId', 'PASS', { nextAfterId });
+
+    const newMessage = `history-new-${randomUUID()}`;
+    await connection.invoke('SendDm', userB.user.id, newMessage);
+    logger.log('signalr.send', 'PASS', { newMessage });
+
+    const deltaPromise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('Timeout waiting for incremental history')), 5000);
+      const handler = (payload) => {
+        const items = getField(payload, 'items') || [];
+        if (items.some(item => getField(item, 'text') === newMessage)) {
+          clearTimeout(timer);
+          connection.off('history', handler);
+          resolve(payload);
+        }
+      };
+      connection.on('history', handler);
+    });
+
+    await connection.invoke('LoadHistory', channel, nextAfterId, 50);
+    const deltaHistory = await deltaPromise;
+    const deltaItems = getField(deltaHistory, 'items') || [];
+    logger.log('history.delta', 'PASS', { items: deltaItems.length });
+
+    const redisTtl = await redis.ttl(key);
+    logger.log('redis.ttl', 'INFO', { key, ttlSeconds: redisTtl });
+
+    const keyType = await redis.type(key);
+    let redisLen;
+    if (keyType === 'stream') {
+      redisLen = await redis.xlen(key);
+    } else if (keyType === 'list') {
+      redisLen = await redis.llen(key);
+    } else {
+      redisLen = null;
+    }
+    logger.log('redis.length', 'INFO', { key, length: redisLen, type: keyType });
+
+    logger.log('summary', 'PASS', { count, redisLen, redisTtl });
+
+    await connection.stop();
+    await redis.quit();
+    logger.close();
+    process.exit(0);
+  } catch (err) {
+    logger.log('summary', 'FAIL', { error: err.message, stack: err.stack });
+    try { await redis.quit(); } catch (e) { /* ignore */ }
+    logger.close();
+    console.error(err);
+    process.exitCode = 1;
+  }
+})();

--- a/tests/realtime/hub-presence.js
+++ b/tests/realtime/hub-presence.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+const { resolveConfig } = require('./utils/config');
+const { JsonLogger } = require('./utils/logger');
+const { ensureUser } = require('./utils/http');
+const { buildConnection, prepareEnvironment } = require('./utils/signalr');
+const { createRedisClient } = require('./utils/redis');
+
+(async () => {
+  const config = resolveConfig();
+  prepareEnvironment();
+  const logger = new JsonLogger('hub-presence', config.logDir);
+  const redis = createRedisClient(config.redisUrl);
+
+  try {
+    await redis.connect();
+    const user = await ensureUser(config.baseUrl, config.users.A, logger);
+
+    const key = `presence:${user.user.id}`;
+    const lastSeenKey = `lastseen:${user.user.id}`;
+
+    const connection = buildConnection(config.presenceHubUrl, user.token, logger, 'presence');
+    await connection.start();
+
+    logger.log('presence.online', 'INFO', { ttlSeconds: config.presence.ttlSeconds });
+    await connection.invoke('Heartbeat');
+    logger.log('presence.heartbeat', 'PASS', { state: 'Online' });
+
+    const ttlAfterHeartbeat = await redis.ttl(key);
+    logger.log('redis.ttl', 'INFO', { key, ttlSeconds: ttlAfterHeartbeat });
+
+    await new Promise(resolve => setTimeout(resolve, config.presence.heartbeatSeconds * 1000));
+    logger.log('presence.state', 'INFO', { state: 'Away', note: `No heartbeat for ${config.presence.heartbeatSeconds}s` });
+
+    const waitMs = (config.presence.ttlSeconds + 10) * 1000;
+    await new Promise(resolve => setTimeout(resolve, waitMs));
+
+    const exists = await redis.exists(key);
+    const lastSeen = await redis.get(lastSeenKey);
+
+    if (exists) {
+      logger.log('presence.offline', 'FAIL', { keyStillExists: true });
+      throw new Error('Presence key still exists after TTL');
+    }
+    logger.log('presence.offline', 'PASS', { lastSeen });
+
+    logger.log('summary', 'PASS', { ttlSeconds: config.presence.ttlSeconds, heartbeatSeconds: config.presence.heartbeatSeconds });
+
+    await connection.stop();
+    await redis.quit();
+    logger.close();
+    process.exit(0);
+  } catch (err) {
+    logger.log('summary', 'FAIL', { error: err.message, stack: err.stack });
+    try { await redis.quit(); } catch (e) { /* ignore */ }
+    logger.close();
+    console.error(err);
+    process.exitCode = 1;
+  }
+})();

--- a/tests/realtime/hub-ratelimit.js
+++ b/tests/realtime/hub-ratelimit.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+const { resolveConfig } = require('./utils/config');
+const { JsonLogger } = require('./utils/logger');
+const { ensureUser } = require('./utils/http');
+const { buildConnection, prepareEnvironment } = require('./utils/signalr');
+
+(async () => {
+  const config = resolveConfig();
+  prepareEnvironment();
+  const logger = new JsonLogger('hub-ratelimit', config.logDir);
+
+  try {
+    const sender = await ensureUser(config.baseUrl, config.users.A, logger);
+    const recipient = await ensureUser(config.baseUrl, config.users.B, logger);
+
+    const channel = `dm:${[sender.user.id, recipient.user.id].sort().join('_')}`;
+    const connection = buildConnection(config.hubUrl, sender.token, logger, 'ratelimit');
+
+    await connection.start();
+    await connection.invoke('JoinChannels', [channel]);
+
+    const totalMessages = Number(process.env.RL_TOTAL || 40);
+    const accepted = [];
+    const rejected = [];
+
+    for (let i = 0; i < totalMessages; i += 1) {
+      const text = `ratelimit-${i}-${Date.now()}`;
+      const start = Date.now();
+      try {
+        await connection.invoke('SendDm', recipient.user.id, text);
+        const latency = Date.now() - start;
+        accepted.push({ text, latency });
+        logger.log('ratelimit.send', 'PASS', { text, index: i }, latency);
+      } catch (err) {
+        rejected.push({ text, error: err.message });
+        logger.log('ratelimit.send', 'FAIL', { text, index: i, error: err.message });
+      }
+    }
+
+    const allowed = config.chat.rateLimitMaxMessages;
+    if (accepted.length !== allowed) {
+      logger.log('validation.accepted', 'FAIL', { expected: allowed, actual: accepted.length });
+      throw new Error(`Expected ${allowed} accepted messages but got ${accepted.length}`);
+    }
+    logger.log('validation.accepted', 'PASS', { expected: allowed, actual: accepted.length });
+
+    const expectedRejected = totalMessages - allowed;
+    if (rejected.length !== expectedRejected) {
+      logger.log('validation.rejected', 'FAIL', { expected: expectedRejected, actual: rejected.length });
+      throw new Error(`Expected ${expectedRejected} rejected messages but got ${rejected.length}`);
+    }
+    const rejectedCodes = rejected.map(r => r.error);
+    logger.log('validation.rejected', 'PASS', { expected: expectedRejected, errorSamples: rejectedCodes.slice(0, 3) });
+
+    accepted.forEach((sample, index) => {
+      logger.log('metric.latency', 'INFO', { metric: 'dm_round_trip', sample: index + 1 }, sample.latency);
+    });
+
+    logger.log('summary', 'PASS', {
+      totalMessages,
+      accepted: accepted.length,
+      rejected: rejected.length,
+      expectedWindowSeconds: config.chat.rateLimitWindowSeconds
+    });
+
+    await connection.stop();
+    logger.close();
+    process.exit(0);
+  } catch (err) {
+    logger.log('summary', 'FAIL', { error: err.message, stack: err.stack });
+    logger.close();
+    console.error(err);
+    process.exitCode = 1;
+  }
+})();

--- a/tests/realtime/hub-reconnect.js
+++ b/tests/realtime/hub-reconnect.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+const { resolveConfig } = require('./utils/config');
+const { JsonLogger } = require('./utils/logger');
+const { ensureUser } = require('./utils/http');
+const { buildConnection, prepareEnvironment } = require('./utils/signalr');
+const { getField } = require('./utils/accessors');
+const { randomUUID } = require('crypto');
+
+function forceTransportDrop(connection) {
+  const transport = connection?.connection?.transport;
+  if (transport && typeof transport.stop === 'function') {
+    transport.stop();
+  } else if (transport?.socket?.close) {
+    transport.socket.close();
+  } else {
+    throw new Error('Unable to access underlying transport for simulated drop');
+  }
+}
+
+(async () => {
+  const config = resolveConfig();
+  prepareEnvironment();
+  const logger = new JsonLogger('hub-reconnect', config.logDir);
+
+  try {
+    const userA = await ensureUser(config.baseUrl, config.users.A, logger);
+    const userB = await ensureUser(config.baseUrl, config.users.B, logger);
+    const channel = `dm:${[userA.user.id, userB.user.id].sort().join('_')}`;
+
+    const connA = buildConnection(config.hubUrl, userA.token, logger, 'A');
+    const connB = buildConnection(config.hubUrl, userB.token, logger, 'B');
+
+    const receivedByA = [];
+    const sendTimes = new Map();
+
+    connA.on('msg', (payload) => {
+      const text = getField(payload, 'text');
+      if (text) {
+        const start = sendTimes.get(text);
+        if (start) {
+          const latency = Date.now() - start;
+          logger.log('receive.dm', 'INFO', { from: getField(payload, 'fromUserId'), text }, latency);
+        }
+        receivedByA.push(text);
+      }
+    });
+
+    await connA.start();
+    await connB.start();
+    await connA.invoke('JoinChannels', [channel]);
+    await connB.invoke('JoinChannels', [channel]);
+
+    const baseline = `reconnect-baseline-${randomUUID()}`;
+    sendTimes.set(baseline, Date.now());
+    await connB.invoke('SendDm', userA.user.id, baseline);
+
+    const waitForBaseline = Date.now() + 3000;
+    while (!receivedByA.includes(baseline) && Date.now() < waitForBaseline) {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    if (!receivedByA.includes(baseline)) {
+      throw new Error('Failed to receive baseline message');
+    }
+
+    logger.log('phase.baseline', 'PASS', {});
+
+    const dropStartedAt = Date.now();
+    const offlinePromise = new Promise((resolve) => {
+      connA.onreconnecting(() => {
+        logger.log('connection.state', 'INFO', { state: 'reconnecting' });
+        resolve();
+      });
+    });
+    forceTransportDrop(connA);
+    await offlinePromise;
+
+    const offlineMessage = `reconnect-offline-${randomUUID()}`;
+    await connB.invoke('SendDm', userA.user.id, offlineMessage);
+    logger.log('phase.offlineSend', 'INFO', { offlineMessage });
+
+    const reconnected = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('Reconnect timeout')), 10000);
+      connA.onreconnected(() => {
+        clearTimeout(timer);
+        const latency = Date.now() - dropStartedAt;
+        logger.log('connection.state', 'PASS', { state: 'reconnected', latencyMs: latency });
+        resolve(latency);
+      });
+    });
+
+    if (reconnected === undefined) {
+      throw new Error('Reconnect failed');
+    }
+
+    const historyPromise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('LoadHistory timeout')), 5000);
+      const handler = (payload) => {
+        const items = getField(payload, 'items') || [];
+        if (items.some(item => getField(item, 'text') === offlineMessage)) {
+          clearTimeout(timer);
+          connA.off('history', handler);
+          resolve(payload);
+        }
+      };
+      connA.on('history', handler);
+    });
+
+    await connA.invoke('LoadHistory', channel, null, 50);
+    const history = await historyPromise;
+
+    const historyItems = getField(history, 'items') || [];
+    const containsOffline = historyItems.some(item => getField(item, 'text') === offlineMessage);
+    if (!containsOffline) {
+      logger.log('validation.history', 'FAIL', { offlineMessage });
+      throw new Error('Offline message missing after reconnect');
+    }
+    logger.log('validation.history', 'PASS', { offlineMessage });
+
+    const duplicates = receivedByA.filter((text, idx) => receivedByA.indexOf(text) !== idx);
+    if (duplicates.length > 0) {
+      logger.log('validation.duplicates', 'FAIL', { duplicates });
+      throw new Error('Duplicate messages detected after reconnect');
+    }
+    logger.log('validation.duplicates', 'PASS', { received: receivedByA.length });
+
+    logger.log('summary', 'PASS', { reconnectLatencyMs: reconnected, recoveredMessages: 1 });
+
+    await connA.stop();
+    await connB.stop();
+    logger.close();
+    process.exit(0);
+  } catch (err) {
+    logger.log('summary', 'FAIL', { error: err.message, stack: err.stack });
+    logger.close();
+    console.error(err);
+    process.exitCode = 1;
+  }
+})();

--- a/tests/realtime/hub-room.js
+++ b/tests/realtime/hub-room.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+const { resolveConfig } = require('./utils/config');
+const { JsonLogger } = require('./utils/logger');
+const { ensureUser, ensureRoom } = require('./utils/http');
+const { buildConnection, prepareEnvironment } = require('./utils/signalr');
+const { getField } = require('./utils/accessors');
+const { randomUUID } = require('crypto');
+
+(async () => {
+  const config = resolveConfig();
+  prepareEnvironment();
+  const logger = new JsonLogger('hub-room', config.logDir);
+
+  try {
+    logger.log('setup.config', 'INFO', { hubUrl: config.hubUrl, roomId: config.room.id });
+    const host = await ensureUser(config.baseUrl, config.users.A, logger);
+    const member = await ensureUser(config.baseUrl, config.users.B, logger);
+
+    const roomId = await ensureRoom(config.baseUrl, host, member, logger, config.room.id);
+    const channel = `room:${roomId}`;
+
+    const hostConn = buildConnection(config.hubUrl, host.token, logger, 'host');
+    const memberConn = buildConnection(config.hubUrl, member.token, logger, 'member');
+
+    const extraConnections = [];
+    const clones = Number(process.env.ROOM_CLONES || 2);
+    for (let i = 0; i < clones; i += 1) {
+      extraConnections.push(buildConnection(config.hubUrl, member.token, logger, `clone-${i + 1}`));
+    }
+
+    const latencies = [];
+    const sendTimes = new Map();
+    const messageId = `ROOM-${randomUUID()}`;
+    const listeners = [];
+
+    function registerListener(connName, connection) {
+      const handler = (payload) => {
+        const text = getField(payload, 'text');
+        if (text === messageId) {
+          const start = sendTimes.get(text);
+          if (start) {
+            const latency = Date.now() - start;
+            latencies.push(latency);
+            logger.log('receive.room', 'PASS', { connection: connName, messageId: getField(payload, 'id') }, latency);
+          }
+        }
+      };
+      connection.on('msg', handler);
+      listeners.push({ connection, handler });
+    }
+
+    registerListener('host', hostConn);
+    registerListener('member', memberConn);
+    extraConnections.forEach((conn, idx) => registerListener(`clone-${idx + 1}`, conn));
+
+    await hostConn.start();
+    await memberConn.start();
+    for (const conn of extraConnections) {
+      await conn.start();
+    }
+
+    logger.log('signalr.connected', 'PASS', { connections: 2 + extraConnections.length, channel });
+
+    await hostConn.invoke('JoinChannels', [channel]);
+    await memberConn.invoke('JoinChannels', [channel]);
+    for (const conn of extraConnections) {
+      await conn.invoke('JoinChannels', [channel]);
+    }
+    logger.log('signalr.join', 'PASS', { channel, participants: 2 + extraConnections.length });
+
+    sendTimes.set(messageId, Date.now());
+    await hostConn.invoke('SendToRoom', roomId, messageId);
+    logger.log('signalr.send', 'PASS', { from: host.user.id, roomId, messageId });
+
+    const expectedReceivers = 2 + extraConnections.length;
+    const waitFor = Date.now() + 5000;
+    let receivedCount = 0;
+    while (Date.now() < waitFor) {
+      receivedCount = latencies.length;
+      if (receivedCount >= expectedReceivers) break;
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    if (latencies.length < expectedReceivers) {
+      logger.log('validation.broadcast', 'FAIL', { expectedReceivers, actualReceivers: latencies.length });
+      throw new Error('Not all participants received broadcast');
+    }
+
+    latencies.forEach((ms, index) => {
+      logger.log('metric.latency', 'INFO', { metric: 'room_round_trip', sample: index + 1 }, ms);
+    });
+
+    logger.log('summary', 'PASS', { samples: latencies.length, roomId, channel });
+
+    for (const { connection, handler } of listeners) {
+      connection.off('msg', handler);
+    }
+
+    await hostConn.stop();
+    await memberConn.stop();
+    for (const conn of extraConnections) {
+      await conn.stop();
+    }
+    logger.log('signalr.stop', 'INFO', {});
+    logger.close();
+    process.exit(0);
+  } catch (err) {
+    logger.log('summary', 'FAIL', { error: err.message, stack: err.stack });
+    logger.close();
+    console.error(err);
+    process.exitCode = 1;
+  }
+})();

--- a/tests/realtime/hub-smoke.js
+++ b/tests/realtime/hub-smoke.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+const { resolveConfig } = require('./utils/config');
+const { JsonLogger } = require('./utils/logger');
+const { ensureUser } = require('./utils/http');
+const { buildConnection, prepareEnvironment } = require('./utils/signalr');
+const { getField } = require('./utils/accessors');
+const { randomUUID } = require('crypto');
+
+(async () => {
+  const config = resolveConfig();
+  prepareEnvironment();
+  const logger = new JsonLogger('hub-smoke', config.logDir);
+
+  try {
+    logger.log('setup.config', 'INFO', { hubUrl: config.hubUrl, baseUrl: config.baseUrl });
+
+    const userA = await ensureUser(config.baseUrl, config.users.A, logger);
+    const userB = await ensureUser(config.baseUrl, config.users.B, logger);
+
+    const pair = [userA.user.id, userB.user.id].sort();
+    const channel = `dm:${pair[0]}_${pair[1]}`;
+    const dmKey = `chat:${channel}`;
+
+    logger.log('setup.channel', 'INFO', { channel, dmKey });
+
+    const connA = buildConnection(config.hubUrl, userA.token, logger, 'A');
+    const connB = buildConnection(config.hubUrl, userB.token, logger, 'B');
+
+    const latencies = [];
+    const received = [];
+    const expectedText = `SMOKE-${randomUUID()}`;
+    const sendTimes = new Map();
+
+    connA.on('msg', (payload) => {
+      const text = getField(payload, 'text');
+      if (text === expectedText) {
+        const started = sendTimes.get(text);
+        if (started) {
+          const latency = Date.now() - started;
+          latencies.push(latency);
+          logger.log('receive.self', 'PASS', {
+            connection: 'A',
+            messageId: getField(payload, 'id'),
+            channel: getField(payload, 'channel')
+          }, latency);
+        }
+        received.push({ connection: 'A', payload });
+      }
+    });
+
+    connB.on('msg', (payload) => {
+      const text = getField(payload, 'text');
+      if (text === expectedText) {
+        const started = sendTimes.get(text);
+        if (started) {
+          const latency = Date.now() - started;
+          latencies.push(latency);
+          logger.log('receive.peer', 'PASS', {
+            connection: 'B',
+            messageId: getField(payload, 'id'),
+            channel: getField(payload, 'channel')
+          }, latency);
+        }
+        received.push({ connection: 'B', payload });
+      }
+    });
+
+    await connA.start();
+    await connB.start();
+
+    logger.log('signalr.connected', 'PASS', { connections: ['A', 'B'] });
+
+    await connA.invoke('JoinChannels', [channel]);
+    await connB.invoke('JoinChannels', [channel]);
+    logger.log('signalr.join', 'PASS', { channel });
+
+    const sendStart = Date.now();
+    sendTimes.set(expectedText, sendStart);
+    await connA.invoke('SendDm', userB.user.id, expectedText);
+    logger.log('signalr.send', 'PASS', { to: userB.user.id, text: expectedText });
+
+    const timeoutMs = 5000;
+    const waitUntil = Date.now() + timeoutMs;
+    while (received.length < 2 && Date.now() < waitUntil) {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    if (received.length < 2) {
+      logger.log('validation.received', 'FAIL', { expected: 2, actual: received.length });
+      throw new Error('Did not receive message on both connections');
+    }
+
+    const orderOk = received.every((entry, idx) => {
+      if (idx === 0) return true;
+      const prev = getField(received[idx - 1].payload, 'sentAt');
+      const current = getField(entry.payload, 'sentAt');
+      return prev <= current;
+    });
+    if (!orderOk) {
+      logger.log('validation.order', 'FAIL', { message: 'Messages not in chronological order' });
+      throw new Error('Message ordering failed');
+    }
+    logger.log('validation.order', 'PASS', { count: received.length });
+
+    const ids = new Set(received.map(r => getField(r.payload, 'id')));
+    if (ids.size !== received.length) {
+      logger.log('validation.duplicate', 'FAIL', { uniqueIds: ids.size, total: received.length });
+      throw new Error('Duplicate message identifiers detected');
+    }
+    logger.log('validation.duplicate', 'PASS', { uniqueIds: ids.size });
+
+    latencies.forEach((ms, index) => {
+      logger.log('metric.latency', 'INFO', { metric: 'dm_round_trip', sample: index + 1 }, ms);
+    });
+
+    logger.log('summary', 'PASS', { samples: latencies.length, channel });
+
+    await connA.stop();
+    await connB.stop();
+    logger.log('signalr.stop', 'INFO', {});
+    logger.close();
+    process.exit(0);
+  } catch (err) {
+    logger.log('summary', 'FAIL', { error: err.message, stack: err.stack });
+    logger.close();
+    console.error(err);
+    process.exitCode = 1;
+  }
+})();

--- a/tests/realtime/k6-room-broadcast.js
+++ b/tests/realtime/k6-room-broadcast.js
@@ -1,0 +1,147 @@
+import http from 'k6/http';
+import ws from 'k6/ws';
+import { check, sleep } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+
+const baseUrl = __ENV.BASE_URL || 'https://localhost:7227';
+const hubUrl = (__ENV.HUB_URL || `${baseUrl}/ws/chat`).replace(/\/$/, '');
+const roomId = __ENV.ROOM_ID;
+const accessToken = __ENV.ACCESS_TOKEN;
+const vusTarget = Number(__ENV.VUS || 50);
+const holdDuration = __ENV.HOLD_DURATION || '1m';
+const messageIntervalMs = Number(__ENV.MESSAGE_INTERVAL_MS || 1000);
+const sessionDurationMs = Number(__ENV.SESSION_DURATION_MS || 60000);
+
+if (!roomId) {
+  throw new Error('ROOM_ID environment variable is required for k6 broadcast test.');
+}
+if (!accessToken) {
+  throw new Error('ACCESS_TOKEN environment variable is required for k6 broadcast test.');
+}
+
+export const options = {
+  scenarios: {
+    broadcast: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: vusTarget },
+        { duration: holdDuration, target: vusTarget },
+        { duration: '30s', target: 0 }
+      ],
+      gracefulRampDown: '10s'
+    }
+  }
+};
+
+const latencyTrend = new Trend('room_broadcast_latency', true);
+const errorRate = new Rate('room_broadcast_errors');
+
+function parseMessages(data) {
+  const records = [];
+  const frames = data.split('\u001e').filter(Boolean);
+  for (const frame of frames) {
+    try {
+      records.push(JSON.parse(frame));
+    } catch (err) {
+      // skip invalid frame
+    }
+  }
+  return records;
+}
+
+export default function () {
+  const negotiateUrl = `${hubUrl}/negotiate?negotiateVersion=1`;
+  const negotiateRes = http.post(negotiateUrl, null, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  });
+
+  check(negotiateRes, {
+    'negotiate status 200': (r) => r.status === 200
+  });
+
+  const negotiateBody = negotiateRes.json();
+  const connectionId = negotiateBody.connectionId;
+  if (!connectionId) {
+    errorRate.add(1);
+    throw new Error(`Missing connectionId in negotiate response: ${negotiateRes.body}`);
+  }
+
+  const wsUrl = hubUrl
+    .replace(/^http/, 'ws')
+    .concat(`?id=${connectionId}&access_token=${encodeURIComponent(accessToken)}`);
+
+  const sendMap = new Map();
+
+  const res = ws.connect(wsUrl, {}, (socket) => {
+    const closeTimer = socket.setTimeout(() => {
+      socket.close();
+    }, sessionDurationMs);
+
+    socket.on('open', () => {
+      socket.send(JSON.stringify({ protocol: 'json', version: 1 }) + '\u001e');
+      const joinMessage = {
+        type: 1,
+        target: 'JoinChannels',
+        arguments: [[`room:${roomId}`]]
+      };
+      socket.send(JSON.stringify(joinMessage) + '\u001e');
+    });
+
+    socket.on('message', (data) => {
+      const records = parseMessages(data);
+      for (const record of records) {
+        if (record.type === 6) {
+          // ping/keep-alive
+          continue;
+        }
+        if (record.type === 1 && record.target === 'msg' && Array.isArray(record.arguments)) {
+          const payload = record.arguments[0];
+          if (payload?.text && sendMap.has(payload.text)) {
+            const started = sendMap.get(payload.text);
+            const latency = Date.now() - started;
+            latencyTrend.add(latency);
+            sendMap.delete(payload.text);
+          }
+        }
+      }
+    });
+
+    socket.on('error', (err) => {
+      errorRate.add(1);
+    });
+
+    socket.on('close', () => {
+      socket.clearTimeout(closeTimer);
+    });
+
+    const sender = () => {
+      const text = `k6-room-${__VU}-${Date.now()}`;
+      sendMap.set(text, Date.now());
+      const message = {
+        type: 1,
+        target: 'SendToRoom',
+        arguments: [roomId, text]
+      };
+      socket.send(JSON.stringify(message) + '\u001e');
+    };
+
+    sender();
+    const interval = socket.setInterval(() => {
+      sender();
+    }, messageIntervalMs);
+
+    socket.setTimeout(() => {
+      socket.clearInterval(interval);
+      socket.close();
+    }, sessionDurationMs);
+  });
+
+  check(res, {
+    'ws status 101': (r) => r && r.status === 101
+  });
+
+  sleep(1);
+}

--- a/tests/realtime/make-report.js
+++ b/tests/realtime/make-report.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { computeQuantiles, asciiBarChart } = require('./utils/metrics');
+
+function readLogs(logDir) {
+  const logs = [];
+  if (!fs.existsSync(logDir)) {
+    return logs;
+  }
+  const files = fs.readdirSync(logDir).filter(f => f.endsWith('.log'));
+  for (const file of files) {
+    const fullPath = path.join(logDir, file);
+    const lines = fs.readFileSync(fullPath, 'utf8').split('\n').filter(Boolean);
+    for (const line of lines) {
+      try {
+        logs.push(JSON.parse(line));
+      } catch (err) {
+        // ignore parse errors
+      }
+    }
+  }
+  return logs;
+}
+
+function groupByCase(logs) {
+  const map = new Map();
+  for (const entry of logs) {
+    if (!map.has(entry.case)) {
+      map.set(entry.case, []);
+    }
+    map.get(entry.case).push(entry);
+  }
+  return map;
+}
+
+function summarizeCase(entries) {
+  const summary = {
+    result: 'UNKNOWN',
+    notes: [],
+    latencies: {},
+    redis: [],
+    presence: [],
+    counts: {}
+  };
+  for (const entry of entries) {
+    if (entry.step === 'summary') {
+      summary.result = entry.result;
+      summary.notes.push(entry.details || {});
+    }
+    if (entry.details?.metric && entry.latencyMs != null) {
+      if (!summary.latencies[entry.details.metric]) {
+        summary.latencies[entry.details.metric] = [];
+      }
+      summary.latencies[entry.details.metric].push(entry.latencyMs);
+    }
+    if (entry.step.startsWith('redis')) {
+      summary.redis.push(entry.details);
+    }
+    if (entry.step.startsWith('presence')) {
+      summary.presence.push({ step: entry.step, details: entry.details });
+    }
+    summary.counts[entry.step] = (summary.counts[entry.step] || 0) + 1;
+  }
+  return summary;
+}
+
+function renderLatencySection(latenciesByMetric) {
+  const sections = [];
+  for (const [metric, samples] of Object.entries(latenciesByMetric)) {
+    const stats = computeQuantiles(samples);
+    sections.push(`- **${metric}**: p50=${stats.p50?.toFixed(1) ?? 'n/a'}ms, p95=${stats.p95?.toFixed(1) ?? 'n/a'}ms, p99=${stats.p99?.toFixed(1) ?? 'n/a'}ms, count=${stats.count}`);
+    sections.push('');
+    sections.push('```');
+    sections.push(asciiBarChart(metric, samples));
+    sections.push('```');
+    sections.push('');
+  }
+  return sections.join('\n');
+}
+
+function renderRedisSection(redisEntries) {
+  if (!redisEntries || redisEntries.length === 0) {
+    return 'No Redis metrics captured.';
+  }
+  const lines = ['| Key | Detail |', '| --- | --- |'];
+  for (const entry of redisEntries) {
+    lines.push(`| ${entry?.key ?? 'n/a'} | ${JSON.stringify(entry)} |`);
+  }
+  return lines.join('\n');
+}
+
+function renderSummaryTable(caseSummaries) {
+  const headers = ['Case', 'Result', 'Notes'];
+  const rows = [headers.join(' | '), headers.map(() => '---').join(' | ')];
+  for (const [caseName, summary] of caseSummaries) {
+    const noteText = summary.notes.map(n => JSON.stringify(n)).join('<br/>');
+    rows.push(`${caseName} | ${summary.result} | ${noteText || ''}`);
+  }
+  return rows.join('\n');
+}
+
+function renderPresenceSection(presenceEntries) {
+  if (!presenceEntries || presenceEntries.length === 0) {
+    return 'No presence transitions captured.';
+  }
+  const lines = ['| Step | Details |', '| --- | --- |'];
+  for (const entry of presenceEntries) {
+    lines.push(`| ${entry.step} | ${JSON.stringify(entry.details)} |`);
+  }
+  return lines.join('\n');
+}
+
+function renderFixSuggestions(caseSummaries) {
+  const failed = Array.from(caseSummaries).filter(([, summary]) => summary.result !== 'PASS');
+  if (failed.length === 0) {
+    return '- ✅ All scenarios passed. No fixes required.';
+  }
+  const suggestions = failed.map(([caseName, summary]) => `- **${caseName}**: Investigate ${JSON.stringify(summary.notes)}`);
+  return suggestions.join('\n');
+}
+
+function main() {
+  const logDir = process.env.LOG_DIR || path.join(__dirname, 'logs');
+  const reportPath = path.join(__dirname, 'REPORT.md');
+  const logs = readLogs(logDir);
+  const grouped = groupByCase(logs);
+  const caseSummaries = new Map();
+  for (const [caseName, entries] of grouped) {
+    caseSummaries.set(caseName, summarizeCase(entries));
+  }
+
+  const sections = [];
+  sections.push('# Realtime Chat Regression Report');
+  sections.push(`_Generated at ${new Date().toISOString()}_`);
+  sections.push('');
+  sections.push('## Summary');
+  sections.push(renderSummaryTable(caseSummaries));
+  sections.push('');
+
+  sections.push('## Latency Distributions');
+  if (caseSummaries.size === 0) {
+    sections.push('No latency samples captured.');
+  } else {
+    for (const [caseName, summary] of caseSummaries) {
+      if (!summary.latencies || Object.keys(summary.latencies).length === 0) continue;
+      sections.push(`### ${caseName}`);
+      sections.push(renderLatencySection(summary.latencies));
+    }
+  }
+
+  sections.push('## Redis Verification');
+  for (const [caseName, summary] of caseSummaries) {
+    if (!summary.redis || summary.redis.length === 0) continue;
+    sections.push(`### ${caseName}`);
+    sections.push(renderRedisSection(summary.redis));
+    sections.push('');
+  }
+
+  sections.push('## Presence Timeline');
+  for (const [caseName, summary] of caseSummaries) {
+    if (!summary.presence || summary.presence.length === 0) continue;
+    sections.push(`### ${caseName}`);
+    sections.push(renderPresenceSection(summary.presence));
+    sections.push('');
+  }
+
+  sections.push('## Fix Suggestions');
+  sections.push(renderFixSuggestions(caseSummaries));
+
+  fs.writeFileSync(reportPath, sections.join('\n'));
+  // eslint-disable-next-line no-console
+  console.log(`Report written to ${reportPath}`);
+}
+
+main();

--- a/tests/realtime/postman_collection.json
+++ b/tests/realtime/postman_collection.json
@@ -1,0 +1,177 @@
+{
+  "info": {
+    "name": "StudentGamerHub Realtime QA",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "Collection covering authentication, abuse reporting, and health probes for StudentGamerHub realtime validation."
+  },
+  "item": [
+    {
+      "name": "Auth - Register Test User",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/auth/user-register",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "auth", "user-register"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"fullName\": \"Realtime QA User\",\n  \"gender\": \"Male\",\n  \"university\": \"SignalR QA Academy\",\n  \"email\": \"{{email}}\",\n  \"phoneNumber\": null,\n  \"password\": \"{{password}}\"\n}"
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Auth - Login",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "if (pm.response.code === 200) {",
+              "  const json = pm.response.json();",
+              "  pm.collectionVariables.set('accessToken', json.accessToken);",
+              "  pm.collectionVariables.set('accessTokenExpiresAtUtc', json.accessExpiresAtUtc);",
+              "}",
+              "pm.test('Received access token', function () {",
+              "  pm.expect(pm.collectionVariables.get('accessToken')).to.be.a('string');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/auth/login",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "auth", "login"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"userNameOrEmail\": \"{{email}}\",\n  \"password\": \"{{password}}\"\n}"
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Auth - Me",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{accessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/auth/me",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "auth", "me"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Abuse - Report Chat Message",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Authorization",
+            "value": "Bearer {{accessToken}}"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/api/abuse/report",
+          "host": ["{{baseUrl}}"],
+          "path": ["api", "abuse", "report"]
+        },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"channel\": \"dm:{{pairChannel}}\",\n  \"messageId\": \"{{messageId}}\",\n  \"text\": \"Flagging abusive language\",\n  \"offenderUserId\": \"{{offenderUserId}}\",\n  \"snapshot\": {\n    \"fromUserId\": \"{{offenderUserId}}\",\n    \"toUserId\": \"{{reporterUserId}}\",\n    \"roomId\": null,\n    \"message\": \"{{messageText}}\"\n  }\n}"
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Health - Ready",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "{{baseUrl}}/ready",
+          "host": ["{{baseUrl}}"],
+          "path": ["ready"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Health - Live",
+      "request": {
+        "method": "GET",
+        "url": {
+          "raw": "{{baseUrl}}/live",
+          "host": ["{{baseUrl}}"],
+          "path": ["live"]
+        }
+      },
+      "response": []
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "https://localhost:7227"
+    },
+    {
+      "key": "email",
+      "value": "realtime-a@studentgamerhub.local"
+    },
+    {
+      "key": "password",
+      "value": "Password123!"
+    },
+    {
+      "key": "accessToken",
+      "value": ""
+    },
+    {
+      "key": "pairChannel",
+      "value": ""
+    },
+    {
+      "key": "messageId",
+      "value": ""
+    },
+    {
+      "key": "offenderUserId",
+      "value": ""
+    },
+    {
+      "key": "reporterUserId",
+      "value": ""
+    },
+    {
+      "key": "messageText",
+      "value": ""
+    }
+  ]
+}

--- a/tests/realtime/utils/accessors.js
+++ b/tests/realtime/utils/accessors.js
@@ -1,0 +1,25 @@
+function getField(obj, key) {
+  if (!obj) return undefined;
+  if (Object.prototype.hasOwnProperty.call(obj, key)) {
+    return obj[key];
+  }
+  const pascal = key.charAt(0).toUpperCase() + key.slice(1);
+  if (Object.prototype.hasOwnProperty.call(obj, pascal)) {
+    return obj[pascal];
+  }
+  const camel = key.charAt(0).toLowerCase() + key.slice(1);
+  if (Object.prototype.hasOwnProperty.call(obj, camel)) {
+    return obj[camel];
+  }
+  const lower = key.toLowerCase();
+  for (const prop of Object.keys(obj)) {
+    if (prop.toLowerCase() === lower) {
+      return obj[prop];
+    }
+  }
+  return undefined;
+}
+
+module.exports = {
+  getField
+};

--- a/tests/realtime/utils/config.js
+++ b/tests/realtime/utils/config.js
@@ -1,0 +1,155 @@
+const fs = require('fs');
+const path = require('path');
+const stripJsonComments = require('strip-json-comments');
+
+function readJsonFileSafe(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const sanitized = stripJsonComments(raw);
+    return JSON.parse(sanitized);
+  } catch (err) {
+    return null;
+  }
+}
+
+function resolveLaunchUrls() {
+  const launchSettings = readJsonFileSafe(path.join(__dirname, '..', '..', '..', 'WebAPI', 'Properties', 'launchSettings.json'));
+  if (!launchSettings?.profiles) {
+    return {};
+  }
+
+  const httpsProfile = Object.values(launchSettings.profiles).find(p => typeof p?.applicationUrl === 'string' && p.applicationUrl.includes('https://'));
+  const httpProfile = Object.values(launchSettings.profiles).find(p => typeof p?.applicationUrl === 'string' && p.applicationUrl.includes('http://'));
+
+  const parseFirstUrl = (profile, preferHttps = false) => {
+    if (!profile?.applicationUrl) return undefined;
+    const parts = profile.applicationUrl.split(';').map(p => p.trim()).filter(Boolean);
+    if (parts.length === 0) return undefined;
+    if (preferHttps) {
+      const https = parts.find(p => p.startsWith('https://'));
+      if (https) return https;
+    }
+    return parts[0];
+  };
+
+  return {
+    httpsUrl: parseFirstUrl(httpsProfile, true),
+    httpUrl: parseFirstUrl(httpProfile)
+  };
+}
+
+function resolveAppSettings() {
+  const devSettings = readJsonFileSafe(path.join(__dirname, '..', '..', '..', 'WebAPI', 'appsettings.Development.json'));
+  const prodSettings = readJsonFileSafe(path.join(__dirname, '..', '..', '..', 'WebAPI', 'appsettings.json'));
+  return {
+    dev: devSettings ?? {},
+    prod: prodSettings ?? {}
+  };
+}
+
+function resolveBaseUrl() {
+  if (process.env.BASE_URL) {
+    return process.env.BASE_URL.replace(/\/$/, '');
+  }
+
+  const { httpsUrl, httpUrl } = resolveLaunchUrls();
+  if (httpsUrl) return httpsUrl.replace(/\/$/, '');
+  if (httpUrl) return httpUrl.replace(/\/$/, '');
+  return 'https://localhost:7227';
+}
+
+function resolveRedis(appSettings) {
+  if (process.env.REDIS) {
+    return process.env.REDIS;
+  }
+
+  const redisConn = appSettings.dev?.Redis?.ConnectionString || appSettings.prod?.Redis?.ConnectionString;
+  if (!redisConn) {
+    return 'redis://localhost:6379';
+  }
+
+  if (redisConn.startsWith('redis://')) {
+    return redisConn;
+  }
+
+  return `redis://${redisConn}`;
+}
+
+function resolveChatOptions(appSettings) {
+  const chat = appSettings.dev?.Chat || appSettings.prod?.Chat || {};
+  return {
+    historyMax: Number(process.env.HISTORY_MAX ?? chat.HistoryMax ?? 200),
+    historyTtlHours: Number(process.env.HISTORY_TTL_HOURS ?? chat.HistoryTtlHours ?? 48),
+    rateLimitWindowSeconds: Number(process.env.RATE_LIMIT_WINDOW ?? chat.RateLimitWindowSeconds ?? 30),
+    rateLimitMaxMessages: Number(process.env.RATE_LIMIT_MAX ?? chat.RateLimitMaxMessages ?? 30)
+  };
+}
+
+function resolvePresenceOptions(appSettings) {
+  const presence = appSettings.dev?.Presence || appSettings.prod?.Presence || {};
+  return {
+    ttlSeconds: Number(process.env.PRESENCE_TTL ?? presence.TtlSeconds ?? 60),
+    heartbeatSeconds: Number(process.env.PRESENCE_HEARTBEAT ?? presence.HeartbeatSeconds ?? 30)
+  };
+}
+
+function buildUserConfig(key, defaults) {
+  return {
+    email: process.env[`${key}_EMAIL`] || defaults.email,
+    password: process.env[`${key}_PASSWORD`] || defaults.password,
+    fullName: process.env[`${key}_FULLNAME`] || defaults.fullName,
+    gender: process.env[`${key}_GENDER`] || defaults.gender,
+    university: process.env[`${key}_UNIVERSITY`] || defaults.university,
+    phone: process.env[`${key}_PHONE`] || defaults.phone
+  };
+}
+
+function resolveConfig() {
+  const appSettings = resolveAppSettings();
+  const baseUrl = resolveBaseUrl();
+  const hubUrl = (process.env.HUB_URL || `${baseUrl}/ws/chat`).replace(/\/$/, '');
+  const presenceHubUrl = (process.env.PRESENCE_HUB_URL || `${baseUrl}/ws/presence`).replace(/\/$/, '');
+  const redisUrl = resolveRedis(appSettings);
+  const chat = resolveChatOptions(appSettings);
+  const presence = resolvePresenceOptions(appSettings);
+
+  const defaults = {
+    A: {
+      email: 'realtime-a@studentgamerhub.local',
+      password: 'Password123!',
+      fullName: 'Realtime QA A',
+      gender: 'Female',
+      university: 'SignalR QA Academy',
+      phone: null
+    },
+    B: {
+      email: 'realtime-b@studentgamerhub.local',
+      password: 'Password123!',
+      fullName: 'Realtime QA B',
+      gender: 'Male',
+      university: 'SignalR QA Academy',
+      phone: null
+    }
+  };
+
+  return {
+    baseUrl,
+    hubUrl,
+    presenceHubUrl,
+    redisUrl,
+    chat,
+    presence,
+    users: {
+      A: buildUserConfig('USER_A', defaults.A),
+      B: buildUserConfig('USER_B', defaults.B)
+    },
+    room: {
+      id: process.env.ROOM_ID ? process.env.ROOM_ID.trim() : null
+    },
+    logDir: process.env.LOG_DIR || path.join(__dirname, '..', 'logs')
+  };
+}
+
+module.exports = {
+  resolveConfig
+};

--- a/tests/realtime/utils/http.js
+++ b/tests/realtime/utils/http.js
@@ -1,0 +1,207 @@
+const fetch = require('cross-fetch');
+const { randomUUID } = require('crypto');
+const { URL } = require('url');
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {})
+    }
+  });
+
+  const text = await response.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch (err) {
+    body = text;
+  }
+
+  return { response, body };
+}
+
+async function login(baseUrl, credentials) {
+  const url = new URL('/api/auth/login', baseUrl).toString();
+  return fetchJson(url, {
+    method: 'POST',
+    body: JSON.stringify({
+      userNameOrEmail: credentials.email,
+      password: credentials.password
+    })
+  });
+}
+
+async function register(baseUrl, payload) {
+  const url = new URL('/api/auth/user-register', baseUrl).toString();
+  return fetchJson(url, {
+    method: 'POST',
+    body: JSON.stringify({
+      fullName: payload.fullName,
+      gender: payload.gender,
+      university: payload.university,
+      email: payload.email,
+      phoneNumber: payload.phone,
+      password: payload.password
+    })
+  });
+}
+
+async function getProfile(baseUrl, token) {
+  const url = new URL('/api/auth/me', baseUrl).toString();
+  return fetchJson(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+}
+
+async function createCommunity(baseUrl, token, name) {
+  const url = new URL('/api/communities', baseUrl).toString();
+  return fetchJson(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      idIgnored: null,
+      name,
+      description: 'Realtime QA Community',
+      school: 'SignalR QA Academy',
+      isPublic: true
+    })
+  });
+}
+
+async function searchCommunities(baseUrl, token, size = 1) {
+  const url = new URL(`/api/communities?size=${size}`, baseUrl).toString();
+  return fetchJson(url, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+}
+
+async function createClub(baseUrl, token, communityId, name) {
+  const url = new URL('/api/clubs', baseUrl).toString();
+  return fetchJson(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      communityId,
+      name,
+      description: 'Realtime QA Club',
+      isPublic: true
+    })
+  });
+}
+
+async function createRoom(baseUrl, token, payload) {
+  const url = new URL('/api/rooms', baseUrl).toString();
+  return fetchJson(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      clubId: payload.clubId,
+      name: payload.name,
+      description: payload.description || 'Realtime QA Room',
+      joinPolicy: payload.joinPolicy ?? 0,
+      password: payload.password ?? null,
+      capacity: payload.capacity ?? null
+    })
+  });
+}
+
+async function joinRoom(baseUrl, token, roomId, password = null) {
+  const url = new URL(`/api/rooms/${roomId}/join`, baseUrl).toString();
+  return fetchJson(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ password })
+  });
+}
+
+async function ensureUser(baseUrl, userConfig, logger) {
+  const identifier = userConfig.email;
+  const loginResult = await login(baseUrl, userConfig);
+  if (loginResult.response.ok) {
+    const token = loginResult.body.accessToken;
+    const profile = await getProfile(baseUrl, token);
+    if (!profile.response.ok) {
+      throw new Error(`Failed to fetch profile for ${identifier}: ${profile.response.status} ${profile.response.statusText}`);
+    }
+    logger?.log('auth.login', 'PASS', { email: identifier, status: loginResult.response.status });
+    return { token, user: profile.body };
+  }
+
+  if (loginResult.response.status === 401 || loginResult.response.status === 400) {
+    logger?.log('auth.register', 'INFO', { email: identifier, status: loginResult.response.status });
+    const regResult = await register(baseUrl, userConfig);
+    if (!regResult.response.ok) {
+      throw new Error(`Failed to register ${identifier}: ${regResult.response.status} ${JSON.stringify(regResult.body)}`);
+    }
+    logger?.log('auth.register', 'PASS', { email: identifier, status: regResult.response.status });
+    return ensureUser(baseUrl, userConfig, logger);
+  }
+
+  throw new Error(`Unexpected login failure for ${identifier}: ${loginResult.response.status} ${JSON.stringify(loginResult.body)}`);
+}
+
+async function ensureRoom(baseUrl, host, member, logger, preferredRoomId = null) {
+  if (preferredRoomId) {
+    logger?.log('room.ensure', 'INFO', { roomId: preferredRoomId, note: 'Using ROOM_ID from environment' });
+    return preferredRoomId;
+  }
+
+  logger?.log('room.ensure', 'INFO', { note: 'Discovering/creating room' });
+  const communityName = `Realtime QA Community ${randomUUID().slice(0, 8)}`;
+  const communitySearch = await searchCommunities(baseUrl, host.token, 1);
+  let communityId;
+  if (communitySearch.response.ok && Array.isArray(communitySearch.body?.items) && communitySearch.body.items.length > 0) {
+    communityId = communitySearch.body.items[0].id;
+    logger?.log('room.community', 'INFO', { communityId, source: 'existing' });
+  } else {
+    const communityCreate = await createCommunity(baseUrl, host.token, communityName);
+    if (!communityCreate.response.ok) {
+      throw new Error(`Failed to create community: ${communityCreate.response.status} ${JSON.stringify(communityCreate.body)}`);
+    }
+    communityId = communityCreate.body?.communityId || communityCreate.body;
+    logger?.log('room.community', 'PASS', { communityId, source: 'created' });
+  }
+
+  const clubName = `Realtime QA Club ${randomUUID().slice(0, 6)}`;
+  const clubCreate = await createClub(baseUrl, host.token, communityId, clubName);
+  if (!clubCreate.response.ok) {
+    throw new Error(`Failed to create club: ${clubCreate.response.status} ${JSON.stringify(clubCreate.body)}`);
+  }
+  const clubId = clubCreate.body?.id || clubCreate.body?.clubId || clubCreate.body;
+  logger?.log('room.club', 'PASS', { clubId });
+
+  const roomName = `Realtime QA Room ${randomUUID().slice(0, 4)}`;
+  const roomCreate = await createRoom(baseUrl, host.token, {
+    clubId,
+    name: roomName,
+    description: 'Realtime automation room',
+    joinPolicy: 0
+  });
+  if (!roomCreate.response.ok) {
+    throw new Error(`Failed to create room: ${roomCreate.response.status} ${JSON.stringify(roomCreate.body)}`);
+  }
+  const roomId = roomCreate.body?.roomId || roomCreate.body?.id || roomCreate.body;
+  logger?.log('room.create', 'PASS', { roomId });
+
+  const joinResult = await joinRoom(baseUrl, member.token, roomId);
+  if (!(joinResult.response.status === 204 || joinResult.response.status === 200)) {
+    throw new Error(`Member failed to join room: ${joinResult.response.status} ${JSON.stringify(joinResult.body)}`);
+  }
+  logger?.log('room.join', 'PASS', { roomId, member: member.user.id });
+
+  return roomId;
+}
+
+module.exports = {
+  fetchJson,
+  ensureUser,
+  ensureRoom,
+  getProfile,
+  joinRoom
+};

--- a/tests/realtime/utils/logger.js
+++ b/tests/realtime/utils/logger.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+
+class JsonLogger {
+  constructor(caseName, logDir) {
+    this.caseName = caseName;
+    this.logDir = logDir;
+    if (!fs.existsSync(logDir)) {
+      fs.mkdirSync(logDir, { recursive: true });
+    }
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    this.filePath = path.join(logDir, `${caseName}-${timestamp}.log`);
+    this.stream = fs.createWriteStream(this.filePath, { flags: 'a' });
+  }
+
+  log(step, result, details = {}, latencyMs = null) {
+    const payload = {
+      timestamp: new Date().toISOString(),
+      case: this.caseName,
+      step,
+      result,
+      latencyMs: latencyMs != null ? Number(latencyMs) : undefined,
+      details
+    };
+    this.stream.write(`${JSON.stringify(payload)}\n`);
+    const consoleParts = [payload.timestamp, `[${result}]`, `${this.caseName}::${step}`];
+    if (latencyMs != null) {
+      consoleParts.push(`${latencyMs.toFixed(2)}ms`);
+    }
+    if (details && Object.keys(details).length > 0) {
+      consoleParts.push(JSON.stringify(details));
+    }
+    // eslint-disable-next-line no-console
+    console.log(consoleParts.join(' '));
+  }
+
+  close() {
+    this.stream.end();
+  }
+}
+
+module.exports = {
+  JsonLogger
+};

--- a/tests/realtime/utils/metrics.js
+++ b/tests/realtime/utils/metrics.js
@@ -1,0 +1,44 @@
+function computeQuantiles(values) {
+  if (!values || values.length === 0) {
+    return { count: 0, p50: null, p95: null, p99: null, min: null, max: null, mean: null };
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const percentile = (p) => {
+    if (sorted.length === 0) return null;
+    const idx = (p / 100) * (sorted.length - 1);
+    const lower = Math.floor(idx);
+    const upper = Math.ceil(idx);
+    if (lower === upper) return sorted[lower];
+    const weight = idx - lower;
+    return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+  };
+  const sum = sorted.reduce((acc, v) => acc + v, 0);
+  return {
+    count: sorted.length,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    mean: sum / sorted.length,
+    p50: percentile(50),
+    p95: percentile(95),
+    p99: percentile(99)
+  };
+}
+
+function asciiBarChart(label, values) {
+  if (!values || values.length === 0) {
+    return `${label}: (no samples)`;
+  }
+  const stats = computeQuantiles(values);
+  const max = stats.max || 1;
+  const scale = max > 0 ? 40 / max : 1;
+  const bars = values.map(v => {
+    const width = Math.max(1, Math.round(v * scale));
+    return `${v.toFixed(1).padStart(6)} ms | ${'#'.repeat(width)}`;
+  });
+  return [`${label} (count=${stats.count}, min=${stats.min?.toFixed(1)}ms, max=${stats.max?.toFixed(1)}ms, mean=${stats.mean?.toFixed(1)}ms)`, ...bars].join('\n');
+}
+
+module.exports = {
+  computeQuantiles,
+  asciiBarChart
+};

--- a/tests/realtime/utils/redis.js
+++ b/tests/realtime/utils/redis.js
@@ -1,0 +1,13 @@
+const IORedis = require('ioredis');
+
+function createRedisClient(redisUrl) {
+  return new IORedis(redisUrl, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 2,
+    enableReadyCheck: true
+  });
+}
+
+module.exports = {
+  createRedisClient
+};

--- a/tests/realtime/utils/signalr.js
+++ b/tests/realtime/utils/signalr.js
@@ -1,0 +1,46 @@
+const signalR = require('@microsoft/signalr');
+const WebSocket = require('ws');
+const fetch = require('cross-fetch');
+
+function prepareEnvironment() {
+  if (typeof global.WebSocket === 'undefined') {
+    global.WebSocket = WebSocket;
+  }
+  if (typeof global.fetch === 'undefined') {
+    global.fetch = fetch;
+  }
+}
+
+function buildConnection(url, token, logger, caseName) {
+  prepareEnvironment();
+  const connection = new signalR.HubConnectionBuilder()
+    .withUrl(url, {
+      accessTokenFactory: () => token,
+      skipNegotiation: true,
+      transport: signalR.HttpTransportType.WebSockets
+    })
+    .withAutomaticReconnect([0, 2000, 5000, 10000])
+    .configureLogging(signalR.LogLevel.Information)
+    .build();
+
+  connection.onreconnecting(err => {
+    logger?.log('signalr.reconnecting', 'INFO', { case: caseName, message: err?.message });
+  });
+  connection.onreconnected(id => {
+    logger?.log('signalr.reconnected', 'INFO', { connectionId: id });
+  });
+  connection.onclose(err => {
+    if (err) {
+      logger?.log('signalr.closed', 'FAIL', { message: err.message });
+    } else {
+      logger?.log('signalr.closed', 'INFO', { graceful: true });
+    }
+  });
+
+  return connection;
+}
+
+module.exports = {
+  buildConnection,
+  prepareEnvironment
+};


### PR DESCRIPTION
## Summary
- add Node.js SignalR harnesses for smoke, functional, and resilience coverage of ChatHub and PresenceHub
- document the realtime regression test plan, checklist, and execution instructions with automated report aggregation
- add a k6 room broadcast load script and Postman collection for supporting REST flows

## Testing
- not run (infrastructure only)

------
https://chatgpt.com/codex/tasks/task_e_68f269e0e85c832da6a7b3a2b9c37eed