### PR TITLE
Add presence REST endpoints backed by Redis snapshots

### DIFF
--- a/DTOs/Presence/PresenceDtos.cs
+++ b/DTOs/Presence/PresenceDtos.cs
@@ -1,0 +1,21 @@
+namespace DTOs.Presence;
+
+public sealed record PresenceSnapshotItem(
+    Guid UserId,
+    bool IsOnline,
+    DateTimeOffset? LastSeenUtc,
+    int? TtlRemainingSeconds);
+
+public sealed record PresenceBatchRequest(IReadOnlyCollection<Guid> UserIds);
+
+public sealed record PresenceBatchResponse(IReadOnlyCollection<PresenceSnapshotItem> Items);
+
+public sealed record PresenceOnlineQuery(int? PageSize = null, string? Cursor = null);
+
+public sealed record PresenceOnlineResponse(
+    IReadOnlyCollection<PresenceSnapshotItem> Items,
+    string? NextCursor);
+
+public sealed record PresenceSummaryRequest(IReadOnlyCollection<Guid>? UserIds);
+
+public sealed record PresenceSummaryResponse(int Online, int? Offline, int Total, string Scope);

--- a/Services/Common/DependencyInjection/DependencyInjection.cs
+++ b/Services/Common/DependencyInjection/DependencyInjection.cs
@@ -38,6 +38,10 @@ namespace Services.Common.DependencyInjection
                         .Bind(configuration.GetSection(PresenceOptions.SectionName))
                         .Validate(o => o.TtlSeconds > 0, "Presence:TtlSeconds must be positive")
                         .Validate(o => o.HeartbeatSeconds > 0, "Presence:HeartbeatSeconds must be positive")
+                        .Validate(o => o.GraceSeconds >= 0, "Presence:GraceSeconds cannot be negative")
+                        .Validate(o => o.MaxBatchSize > 0, "Presence:MaxBatchSize must be positive")
+                        .Validate(o => o.DefaultPageSize > 0, "Presence:DefaultPageSize must be positive")
+                        .Validate(o => o.MaxPageSize >= o.DefaultPageSize, "Presence:MaxPageSize must be >= DefaultPageSize")
                         .ValidateOnStart();
                 // KHÔNG đăng ký singleton .Value để giữ hot-reload
             }
@@ -60,6 +64,8 @@ namespace Services.Common.DependencyInjection
             // 5) Convention registrations
             RegisterCrudServices(services, asm);
             RegisterServiceInterfacesByConvention(services, asm);
+
+            services.AddScoped<IPresenceReader, RedisPresenceReader>();
 
             return services;
         }

--- a/Services/Presence/IPresenceReader.cs
+++ b/Services/Presence/IPresenceReader.cs
@@ -1,0 +1,13 @@
+using BusinessObjects.Common.Results;
+using DTOs.Presence;
+
+namespace Services.Presence;
+
+public interface IPresenceReader
+{
+    Task<Result<PresenceOnlineResponse>> GetOnlineAsync(PresenceOnlineQuery query, CancellationToken ct);
+
+    Task<Result<IReadOnlyCollection<PresenceSnapshotItem>>> GetBatchAsync(IReadOnlyCollection<Guid> userIds, CancellationToken ct);
+
+    Task<Result<PresenceSummaryResponse>> GetSummaryAsync(PresenceSummaryRequest request, CancellationToken ct);
+}

--- a/Services/Presence/PresenceKeyHelper.cs
+++ b/Services/Presence/PresenceKeyHelper.cs
@@ -1,0 +1,27 @@
+using StackExchange.Redis;
+
+namespace Services.Presence;
+
+internal static class PresenceKeyHelper
+{
+    public static string NormalizePrefix(string? prefix)
+    {
+        if (string.IsNullOrWhiteSpace(prefix))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = prefix.Trim();
+        return trimmed.EndsWith(":", StringComparison.Ordinal)
+            ? trimmed
+            : string.Concat(trimmed, ":");
+    }
+
+    public static RedisKey GetPresenceKey(string prefix, Guid userId) => $"{prefix}presence:{userId:D}";
+
+    public static RedisKey GetLastSeenKey(string prefix, Guid userId) => $"{prefix}lastseen:{userId:D}";
+
+    public static RedisKey GetIndexKey(string prefix) => $"{prefix}presence:index";
+
+    public static RedisValue GetMember(Guid userId) => userId.ToString("D");
+}

--- a/Services/Presence/PresenceOptions.cs
+++ b/Services/Presence/PresenceOptions.cs
@@ -7,4 +7,14 @@ public sealed class PresenceOptions
     public int TtlSeconds { get; init; } = 60;
 
     public int HeartbeatSeconds { get; init; } = 30;
+
+    public string KeyPrefix { get; init; } = "sg";
+
+    public int GraceSeconds { get; init; } = 5;
+
+    public int MaxBatchSize { get; init; } = 200;
+
+    public int DefaultPageSize { get; init; } = 100;
+
+    public int MaxPageSize { get; init; } = 500;
 }

--- a/Services/Presence/RedisPresenceReader.cs
+++ b/Services/Presence/RedisPresenceReader.cs
@@ -1,0 +1,351 @@
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using BusinessObjects.Common.Results;
+using DTOs.Presence;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace Services.Presence;
+
+public sealed class RedisPresenceReader : IPresenceReader
+{
+    private readonly IConnectionMultiplexer _redis;
+    private readonly PresenceOptions _options;
+    private readonly string _prefix;
+
+    public RedisPresenceReader(IConnectionMultiplexer redis, IOptions<PresenceOptions> options)
+    {
+        _redis = redis ?? throw new ArgumentNullException(nameof(redis));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _prefix = PresenceKeyHelper.NormalizePrefix(_options.KeyPrefix);
+    }
+
+    public Task<Result<PresenceOnlineResponse>> GetOnlineAsync(PresenceOnlineQuery query, CancellationToken ct)
+    {
+        query ??= new PresenceOnlineQuery();
+        var requestedSize = query.PageSize ?? _options.DefaultPageSize;
+        if (requestedSize <= 0)
+        {
+            return Task.FromResult(Result<PresenceOnlineResponse>.Failure(
+                new Error(Error.Codes.Validation, "pageSize must be positive")));
+        }
+
+        if (requestedSize > _options.MaxPageSize)
+        {
+            return Task.FromResult(Result<PresenceOnlineResponse>.Failure(
+                new Error(Error.Codes.Validation, $"pageSize cannot exceed {_options.MaxPageSize}")));
+        }
+
+        if (!TryDecodeCursor(query.Cursor, out var cursorScore, out var cursorMember))
+        {
+            return Task.FromResult(Result<PresenceOnlineResponse>.Failure(
+                new Error(Error.Codes.Validation, "cursor is invalid")));
+        }
+
+        return ResultExtensions.TryAsync(async () =>
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var db = _redis.GetDatabase();
+            var now = DateTimeOffset.UtcNow;
+            var threshold = now.AddSeconds(-_options.GraceSeconds).ToUnixTimeMilliseconds();
+            var indexKey = PresenceKeyHelper.GetIndexKey(_prefix);
+
+            await db.SortedSetRemoveRangeByScoreAsync(indexKey, double.NegativeInfinity, threshold - 1)
+                .ConfigureAwait(false);
+
+            var startScore = cursorScore.HasValue ? Math.Max(cursorScore.Value, threshold) : threshold;
+            var fetchSize = requestedSize + 1;
+            var rawEntries = await db.SortedSetRangeByScoreWithScoresAsync(
+                    indexKey,
+                    startScore,
+                    double.PositiveInfinity,
+                    Exclude.None,
+                    Order.Ascending,
+                    0,
+                    fetchSize + (cursorMember is null ? 0 : 1))
+                .ConfigureAwait(false);
+
+            var filteredEntries = new List<SortedSetEntry>(rawEntries.Length);
+            foreach (var entry in rawEntries)
+            {
+                if (entry.Element.IsNullOrEmpty)
+                {
+                    continue;
+                }
+
+                var element = entry.Element.ToString();
+                if (!Guid.TryParse(element, out _))
+                {
+                    continue;
+                }
+
+                var expiryMs = ToMilliseconds(entry.Score);
+                if (expiryMs < threshold)
+                {
+                    continue;
+                }
+
+                if (cursorScore.HasValue)
+                {
+                    if (expiryMs < cursorScore.Value)
+                    {
+                        continue;
+                    }
+
+                    if (expiryMs == cursorScore.Value && cursorMember is not null)
+                    {
+                        var comparison = string.CompareOrdinal(element, cursorMember);
+                        if (comparison <= 0)
+                        {
+                            continue;
+                        }
+                    }
+                }
+
+                filteredEntries.Add(entry);
+                if (filteredEntries.Count >= requestedSize + 1)
+                {
+                    break;
+                }
+            }
+
+            var hasMore = filteredEntries.Count > requestedSize;
+            if (hasMore)
+            {
+                filteredEntries = filteredEntries.Take(requestedSize).ToList();
+            }
+
+            var userEntries = filteredEntries.Take(requestedSize).ToArray();
+            if (userEntries.Length == 0)
+            {
+                return new PresenceOnlineResponse(Array.Empty<PresenceSnapshotItem>(), null);
+            }
+
+            var batch = db.CreateBatch();
+            var lastSeenTasks = new Dictionary<Guid, Task<RedisValue>>(userEntries.Length);
+            foreach (var entry in userEntries)
+            {
+                var userId = Guid.Parse(entry.Element.ToString());
+                lastSeenTasks[userId] = batch.StringGetAsync(PresenceKeyHelper.GetLastSeenKey(_prefix, userId));
+            }
+
+            batch.Execute();
+            await Task.WhenAll(lastSeenTasks.Values).ConfigureAwait(false);
+
+            var items = new List<PresenceSnapshotItem>(userEntries.Length);
+            foreach (var entry in userEntries)
+            {
+                var userId = Guid.Parse(entry.Element.ToString());
+                var snapshot = CreateSnapshot(userId, entry.Score, now, lastSeenTasks[userId].Result);
+                items.Add(snapshot);
+            }
+
+            var nextCursor = hasMore
+                ? EncodeCursor(ToMilliseconds(userEntries[^1].Score), userEntries[^1].Element.ToString())
+                : null;
+
+            return new PresenceOnlineResponse(items, nextCursor);
+        });
+    }
+
+    public Task<Result<IReadOnlyCollection<PresenceSnapshotItem>>> GetBatchAsync(
+        IReadOnlyCollection<Guid> userIds,
+        CancellationToken ct)
+    {
+        if (userIds is null)
+        {
+            return Task.FromResult(Result<IReadOnlyCollection<PresenceSnapshotItem>>.Failure(
+                new Error(Error.Codes.Validation, "userIds are required")));
+        }
+
+        if (userIds.Count == 0)
+        {
+            return Task.FromResult(Result<IReadOnlyCollection<PresenceSnapshotItem>>.Failure(
+                new Error(Error.Codes.Validation, "userIds cannot be empty")));
+        }
+
+        if (userIds.Count > _options.MaxBatchSize)
+        {
+            return Task.FromResult(Result<IReadOnlyCollection<PresenceSnapshotItem>>.Failure(
+                new Error(Error.Codes.Validation, $"userIds cannot exceed {_options.MaxBatchSize}")));
+        }
+
+        var orderedUniqueIds = new List<Guid>(userIds.Count);
+        var seen = new HashSet<Guid>();
+        foreach (var id in userIds)
+        {
+            if (id == Guid.Empty || !seen.Add(id))
+            {
+                continue;
+            }
+
+            orderedUniqueIds.Add(id);
+        }
+
+        if (orderedUniqueIds.Count == 0)
+        {
+            return Task.FromResult(Result<IReadOnlyCollection<PresenceSnapshotItem>>.Failure(
+                new Error(Error.Codes.Validation, "userIds are invalid")));
+        }
+
+        return ResultExtensions.TryAsync(async () =>
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var db = _redis.GetDatabase();
+            var batch = db.CreateBatch();
+            var scoreTasks = new Dictionary<Guid, Task<double?>>(orderedUniqueIds.Count);
+            var lastSeenTasks = new Dictionary<Guid, Task<RedisValue>>(orderedUniqueIds.Count);
+            var indexKey = PresenceKeyHelper.GetIndexKey(_prefix);
+            foreach (var id in orderedUniqueIds)
+            {
+                scoreTasks[id] = batch.SortedSetScoreAsync(indexKey, PresenceKeyHelper.GetMember(id));
+                lastSeenTasks[id] = batch.StringGetAsync(PresenceKeyHelper.GetLastSeenKey(_prefix, id));
+            }
+
+            batch.Execute();
+            await Task.WhenAll(scoreTasks.Values).ConfigureAwait(false);
+            await Task.WhenAll(lastSeenTasks.Values).ConfigureAwait(false);
+
+            var now = DateTimeOffset.UtcNow;
+            var items = new List<PresenceSnapshotItem>(orderedUniqueIds.Count);
+            foreach (var id in orderedUniqueIds)
+            {
+                var score = scoreTasks[id].Result;
+                var lastSeen = lastSeenTasks[id].Result;
+                var snapshot = CreateSnapshot(id, score, now, lastSeen);
+                items.Add(snapshot);
+            }
+
+            return (IReadOnlyCollection<PresenceSnapshotItem>)items;
+        });
+    }
+
+    public async Task<Result<PresenceSummaryResponse>> GetSummaryAsync(PresenceSummaryRequest request, CancellationToken ct)
+    {
+        request ??= new PresenceSummaryRequest(null);
+        if (request.UserIds is { Count: > 0 })
+        {
+            var batchResult = await GetBatchAsync(request.UserIds, ct).ConfigureAwait(false);
+            if (!batchResult.IsSuccess)
+            {
+                return Result<PresenceSummaryResponse>.Failure(batchResult.Error);
+            }
+
+            var items = batchResult.Value;
+            var online = items.Count(x => x.IsOnline);
+            var offline = items.Count - online;
+            return Result<PresenceSummaryResponse>.Success(
+                new PresenceSummaryResponse(online, offline, items.Count, "batch"));
+        }
+
+        if (request.UserIds is { Count: 0 })
+        {
+            return Result<PresenceSummaryResponse>.Failure(
+                new Error(Error.Codes.Validation, "userIds cannot be empty"));
+        }
+
+        return await ResultExtensions.TryAsync(async () =>
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var db = _redis.GetDatabase();
+            var now = DateTimeOffset.UtcNow;
+            var threshold = now.AddSeconds(-_options.GraceSeconds).ToUnixTimeMilliseconds();
+            var indexKey = PresenceKeyHelper.GetIndexKey(_prefix);
+
+            await db.SortedSetRemoveRangeByScoreAsync(indexKey, double.NegativeInfinity, threshold - 1)
+                .ConfigureAwait(false);
+
+            var count = await db.SortedSetLengthAsync(indexKey, threshold, double.PositiveInfinity)
+                .ConfigureAwait(false);
+            var onlineCount = count > int.MaxValue ? int.MaxValue : (int)count;
+
+            return new PresenceSummaryResponse(onlineCount, null, onlineCount, "global");
+        }).ConfigureAwait(false);
+    }
+
+    private PresenceSnapshotItem CreateSnapshot(Guid userId, double? score, DateTimeOffset now, RedisValue lastSeenValue)
+    {
+        if (!score.HasValue)
+        {
+            return new PresenceSnapshotItem(userId, false, ParseLastSeen(lastSeenValue), null);
+        }
+
+        var expiry = DateTimeOffset.FromUnixTimeMilliseconds(ToMilliseconds(score.Value));
+        var secondsRemaining = (int)Math.Floor((expiry - now).TotalSeconds);
+        var isOnline = secondsRemaining >= -_options.GraceSeconds;
+        var ttl = isOnline ? secondsRemaining : (int?)null;
+        var lastSeen = ParseLastSeen(lastSeenValue);
+
+        return new PresenceSnapshotItem(userId, isOnline, lastSeen, ttl);
+    }
+
+    private static DateTimeOffset? ParseLastSeen(RedisValue value)
+    {
+        if (value.IsNullOrEmpty)
+        {
+            return null;
+        }
+
+        if (DateTimeOffset.TryParse(value.ToString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed))
+        {
+            return parsed.ToUniversalTime();
+        }
+
+        return null;
+    }
+
+    private static bool TryDecodeCursor(string? cursor, out long? score, out string? member)
+    {
+        score = null;
+        member = null;
+        if (string.IsNullOrWhiteSpace(cursor))
+        {
+            return true;
+        }
+
+        try
+        {
+            var raw = Encoding.UTF8.GetString(Convert.FromBase64String(cursor));
+            var parts = raw.Split('|', 2, StringSplitOptions.TrimEntries);
+            if (parts.Length != 2)
+            {
+                return false;
+            }
+
+            if (!long.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedScore))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(parts[1]))
+            {
+                return false;
+            }
+
+            score = parsedScore;
+            member = parts[1];
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string? EncodeCursor(long score, string? member)
+    {
+        if (string.IsNullOrWhiteSpace(member))
+        {
+            return null;
+        }
+
+        var payload = FormattableString.Invariant($"{score}|{member}");
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(payload));
+    }
+
+    private static long ToMilliseconds(double score) => (long)Math.Round(score, MidpointRounding.AwayFromZero);
+}

--- a/Tests/Services.Presence.Tests/PresenceServiceTests.cs
+++ b/Tests/Services.Presence.Tests/PresenceServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using NSubstitute;
 using StackExchange.Redis;
 using Xunit;
+using System.Linq;
 
 namespace Services.Presence.Tests;
 
@@ -11,8 +12,18 @@ public sealed class PresenceServiceTests
     private readonly IConnectionMultiplexer _connection = Substitute.For<IConnectionMultiplexer>();
     private readonly IDatabase _database = Substitute.For<IDatabase>();
     private readonly IBatch _batch = Substitute.For<IBatch>();
-    private readonly PresenceOptions _options = new() { TtlSeconds = 60, HeartbeatSeconds = 30 };
+    private readonly PresenceOptions _options = new()
+    {
+        TtlSeconds = 60,
+        HeartbeatSeconds = 30,
+        KeyPrefix = "sg",
+        GraceSeconds = 5,
+        MaxBatchSize = 200,
+        DefaultPageSize = 100,
+        MaxPageSize = 500
+    };
     private readonly Dictionary<string, CacheEntry> _store = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<string, double>> _sortedSets = new(StringComparer.Ordinal);
     private readonly PresenceService _service;
 
     public PresenceServiceTests()
@@ -20,7 +31,7 @@ public sealed class PresenceServiceTests
         _connection.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(_database);
         _database.CreateBatch(Arg.Any<object>()).Returns(_batch);
 
-        _database.StringSetAsync(
+        _batch.StringSetAsync(
             Arg.Any<RedisKey>(),
             Arg.Any<RedisValue>(),
             Arg.Any<TimeSpan?>(),
@@ -35,11 +46,77 @@ public sealed class PresenceServiceTests
             return Task.FromResult(true);
         });
 
-        _database.KeyExistsAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
-            .Returns(ci => Task.FromResult(IsAlive(ci.Arg<RedisKey>().ToString())));
+        _batch.SortedSetAddAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<double>(),
+                Arg.Any<When>(),
+                Arg.Any<CommandFlags>())
+            .Returns(ci =>
+            {
+                var key = ci.Arg<RedisKey>().ToString();
+                var member = ci.Arg<RedisValue>().ToString();
+                var score = ci.Arg<double>();
+                if (!_sortedSets.TryGetValue(key, out var set))
+                {
+                    set = new Dictionary<string, double>(StringComparer.Ordinal);
+                    _sortedSets[key] = set;
+                }
 
-        _batch.KeyExistsAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
-            .Returns(ci => Task.FromResult(IsAlive(ci.Arg<RedisKey>().ToString())));
+                set[member] = score;
+                return Task.FromResult(true);
+            });
+
+        _batch.SortedSetRemoveRangeByScoreAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<double>(),
+                Arg.Any<double>(),
+                Arg.Any<Exclude>(),
+                Arg.Any<CommandFlags>())
+            .Returns(ci =>
+            {
+                var key = ci.Arg<RedisKey>().ToString();
+                var min = ci.Arg<double>();
+                var max = ci.Arg<double>();
+                if (!_sortedSets.TryGetValue(key, out var set))
+                {
+                    return Task.FromResult(0L);
+                }
+
+                var removed = set
+                    .Where(kvp => kvp.Value >= min && kvp.Value <= max)
+                    .Select(kvp => kvp.Key)
+                    .ToList();
+
+                foreach (var member in removed)
+                {
+                    set.Remove(member);
+                }
+
+                return Task.FromResult((long)removed.Count);
+            });
+
+        _database.SortedSetScoreAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<CommandFlags>())
+            .Returns(ci =>
+            {
+                var key = ci.Arg<RedisKey>().ToString();
+                var member = ci.Arg<RedisValue>().ToString();
+                if (_sortedSets.TryGetValue(key, out var set) && set.TryGetValue(member, out var score))
+                {
+                    return Task.FromResult<double?>(score);
+                }
+
+                return Task.FromResult<double?>(null);
+            });
+
+        _batch.SortedSetScoreAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<CommandFlags>())
+            .Returns(ci => _database.SortedSetScoreAsync(ci.Arg<RedisKey>(), ci.Arg<RedisValue>(), ci.Arg<CommandFlags>()));
 
         // PresenceService uses IBatch.Execute(); KeyExistsAsync enqueues operations and Execute() flushes them.
         _batch.When(b => b.Execute()).Do(_ => { /* no-op for substitute */ });
@@ -55,9 +132,12 @@ public sealed class PresenceServiceTests
         var result = await _service.HeartbeatAsync(userId);
 
         result.IsSuccess.Should().BeTrue();
-        _store.TryGetValue($"presence:{userId}", out var entry).Should().BeTrue();
+        _store.TryGetValue($"sg:presence:{userId}", out var entry).Should().BeTrue();
         entry!.ExpiresAt.Should().NotBeNull();
         entry.ExpiresAt!.Value.Should().BeCloseTo(DateTime.UtcNow.AddSeconds(_options.TtlSeconds), TimeSpan.FromSeconds(2));
+
+        _sortedSets.TryGetValue("sg:presence:index", out var set).Should().BeTrue();
+        set!.ContainsKey(userId.ToString("D")).Should().BeTrue();
     }
 
     [Fact]
@@ -94,8 +174,10 @@ public sealed class PresenceServiceTests
         var userId = Guid.NewGuid();
         await _service.HeartbeatAsync(userId);
 
-        var key = $"presence:{userId}";
+        var key = $"sg:presence:{userId}";
         _store[key] = _store[key] with { ExpiresAt = DateTime.UtcNow.AddSeconds(-1) };
+        _sortedSets["sg:presence:index"][userId.ToString("D")] =
+            DateTimeOffset.UtcNow.AddSeconds(-_options.GraceSeconds - 5).ToUnixTimeMilliseconds();
 
         var result = await _service.IsOnlineAsync(userId);
 

--- a/Tests/Services.Presence.Tests/RedisPresenceReaderTests.cs
+++ b/Tests/Services.Presence.Tests/RedisPresenceReaderTests.cs
@@ -1,0 +1,212 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using StackExchange.Redis;
+using Xunit;
+using System.Linq;
+
+namespace Services.Presence.Tests;
+
+public sealed class RedisPresenceReaderTests
+{
+    private readonly IConnectionMultiplexer _connection = Substitute.For<IConnectionMultiplexer>();
+    private readonly IDatabase _database = Substitute.For<IDatabase>();
+    private readonly IBatch _batch = Substitute.For<IBatch>();
+    private readonly PresenceOptions _options = new()
+    {
+        TtlSeconds = 60,
+        HeartbeatSeconds = 30,
+        KeyPrefix = "sg",
+        GraceSeconds = 5,
+        MaxBatchSize = 200,
+        DefaultPageSize = 100,
+        MaxPageSize = 500
+    };
+    private readonly Dictionary<Guid, double> _scores = new();
+    private readonly Dictionary<Guid, string> _lastSeen = new();
+    private readonly RedisPresenceReader _reader;
+
+    public RedisPresenceReaderTests()
+    {
+        _connection.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(_database);
+        _database.CreateBatch(Arg.Any<object>()).Returns(_batch);
+
+        _batch.When(b => b.Execute()).Do(_ => { });
+
+        _batch.SortedSetScoreAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<CommandFlags>())
+            .Returns(ci =>
+            {
+                var member = ci.Arg<RedisValue>().ToString();
+                var id = Guid.Parse(member);
+                return Task.FromResult(_scores.TryGetValue(id, out var score) ? (double?)score : null);
+            });
+
+        _batch.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(ci =>
+            {
+                var key = ci.Arg<RedisKey>().ToString();
+                var idPart = key.Split(':').Last();
+                if (Guid.TryParse(idPart, out var id) && _lastSeen.TryGetValue(id, out var value))
+                {
+                    return Task.FromResult((RedisValue)value);
+                }
+
+                return Task.FromResult(RedisValue.Null);
+            });
+
+        _database.SortedSetRemoveRangeByScoreAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<double>(),
+                Arg.Any<double>(),
+                Arg.Any<Exclude>(),
+                Arg.Any<CommandFlags>())
+            .Returns(ci =>
+            {
+                var min = ci.Arg<double>();
+                var max = ci.Arg<double>();
+                var removed = _scores
+                    .Where(kvp => kvp.Value >= min && kvp.Value <= max)
+                    .Select(kvp => kvp.Key)
+                    .ToList();
+
+                foreach (var id in removed)
+                {
+                    _scores.Remove(id);
+                }
+
+                return Task.FromResult((long)removed.Count);
+            });
+
+        _database.SortedSetRangeByScoreWithScoresAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<double>(),
+                Arg.Any<double>(),
+                Arg.Any<Exclude>(),
+                Arg.Any<Order>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<CommandFlags>())
+            .Returns(ci =>
+            {
+                var min = ci.Arg<double>();
+                var take = ci.Arg<long>(6);
+                if (take <= 0)
+                {
+                    take = _scores.Count;
+                }
+
+                var entries = _scores
+                    .Where(kvp => kvp.Value >= min)
+                    .OrderBy(kvp => kvp.Value)
+                    .ThenBy(kvp => kvp.Key)
+                    .Take((int)take)
+                    .Select(kvp => new SortedSetEntry(kvp.Key.ToString("D"), kvp.Value))
+                    .ToArray();
+
+                return Task.FromResult(entries);
+            });
+
+        _database.SortedSetLengthAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<double>(),
+                Arg.Any<double>(),
+                Arg.Any<Exclude>(),
+                Arg.Any<CommandFlags>())
+            .Returns(ci =>
+            {
+                var min = ci.Arg<double>();
+                var count = _scores.Values.Count(score => score >= min);
+                return Task.FromResult((long)count);
+            });
+
+        _reader = new RedisPresenceReader(_connection, Options.Create(_options));
+    }
+
+    [Fact]
+    public async Task GetBatchAsync_ShouldReturnSnapshotsWithOnlineStatus()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var online = Guid.NewGuid();
+        var offline = Guid.NewGuid();
+        _scores[online] = now.AddSeconds(30).ToUnixTimeMilliseconds();
+        _lastSeen[online] = now.ToString("O");
+        _lastSeen[offline] = now.AddMinutes(-5).ToString("O");
+
+        var result = await _reader.GetBatchAsync(new[] { online, offline }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+
+        var onlineSnapshot = result.Value.Single(x => x.UserId == online);
+        onlineSnapshot.IsOnline.Should().BeTrue();
+        onlineSnapshot.TtlRemainingSeconds.Should().NotBeNull();
+        onlineSnapshot.LastSeenUtc.Should().BeCloseTo(now, TimeSpan.FromSeconds(1));
+
+        var offlineSnapshot = result.Value.Single(x => x.UserId == offline);
+        offlineSnapshot.IsOnline.Should().BeFalse();
+        offlineSnapshot.TtlRemainingSeconds.Should().BeNull();
+        offlineSnapshot.LastSeenUtc.Should().BeCloseTo(now.AddMinutes(-5), TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task GetOnlineAsync_ShouldReturnPagedResultsWithCursor()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var third = Guid.NewGuid();
+        var expired = Guid.NewGuid();
+
+        _scores[first] = now.AddSeconds(20).ToUnixTimeMilliseconds();
+        _scores[second] = now.AddSeconds(40).ToUnixTimeMilliseconds();
+        _scores[third] = now.AddSeconds(60).ToUnixTimeMilliseconds();
+        _scores[expired] = now.AddSeconds(-_options.GraceSeconds - 10).ToUnixTimeMilliseconds();
+
+        _lastSeen[first] = now.ToString("O");
+        _lastSeen[second] = now.ToString("O");
+        _lastSeen[third] = now.ToString("O");
+        _lastSeen[expired] = now.ToString("O");
+
+        var firstPage = await _reader.GetOnlineAsync(new PresenceOnlineQuery(2, null), CancellationToken.None);
+
+        firstPage.IsSuccess.Should().BeTrue();
+        firstPage.Value.Items.Should().HaveCount(2);
+        firstPage.Value.NextCursor.Should().NotBeNull();
+        _scores.ContainsKey(expired).Should().BeFalse("expired entries should be cleaned");
+
+        var secondPage = await _reader.GetOnlineAsync(new PresenceOnlineQuery(2, firstPage.Value.NextCursor), CancellationToken.None);
+
+        secondPage.IsSuccess.Should().BeTrue();
+        secondPage.Value.Items.Should().ContainSingle(x => x.UserId == third);
+        secondPage.Value.NextCursor.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ShouldReturnGlobalCounts()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var online = Guid.NewGuid();
+        var offline = Guid.NewGuid();
+        _scores[online] = now.AddSeconds(45).ToUnixTimeMilliseconds();
+        _scores[offline] = now.AddSeconds(-_options.GraceSeconds - 20).ToUnixTimeMilliseconds();
+
+        var result = await _reader.GetSummaryAsync(new PresenceSummaryRequest(null), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Online.Should().Be(1);
+        result.Value.Offline.Should().BeNull();
+        result.Value.Total.Should().Be(1);
+        result.Value.Scope.Should().Be("global");
+
+        var scoped = await _reader.GetSummaryAsync(new PresenceSummaryRequest(new[] { online, offline }), CancellationToken.None);
+
+        scoped.IsSuccess.Should().BeTrue();
+        scoped.Value.Online.Should().Be(1);
+        scoped.Value.Offline.Should().Be(1);
+        scoped.Value.Total.Should().Be(2);
+        scoped.Value.Scope.Should().Be("batch");
+    }
+}

--- a/WebAPI/Controllers/PresenceController.cs
+++ b/WebAPI/Controllers/PresenceController.cs
@@ -1,0 +1,78 @@
+using BusinessObjects.Common.Results;
+using DTOs.Presence;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Services.Presence;
+using WebApi.Common;
+
+namespace WebAPI.Controllers;
+
+[ApiController]
+[Route("api/presence")]
+[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+public sealed class PresenceController : ControllerBase
+{
+    private readonly IPresenceReader _reader;
+
+    public PresenceController(IPresenceReader reader)
+    {
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+    }
+
+    [HttpGet("online")]
+    [Authorize(Roles = "Admin")]
+    [EnableRateLimiting("PresenceAdminReads")]
+    [ProducesResponseType(typeof(PresenceOnlineResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult> GetOnline([FromQuery] PresenceOnlineQuery? query, CancellationToken ct)
+    {
+        var result = await _reader
+            .GetOnlineAsync(query ?? new PresenceOnlineQuery(), ct)
+            .ConfigureAwait(false);
+
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+
+    [HttpPost("batch")]
+    [EnableRateLimiting("PresenceBatchReads")]
+    [ProducesResponseType(typeof(PresenceBatchResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult> GetBatch([FromBody] PresenceBatchRequest? request, CancellationToken ct)
+    {
+        request ??= new PresenceBatchRequest(Array.Empty<Guid>());
+        var result = await _reader
+            .GetBatchAsync(request.UserIds, ct)
+            .ConfigureAwait(false);
+
+        return this.ToActionResult(result, v => new PresenceBatchResponse(v), StatusCodes.Status200OK);
+    }
+
+    [HttpPost("summary")]
+    [EnableRateLimiting("PresenceAdminReads")]
+    [ProducesResponseType(typeof(PresenceSummaryResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult> GetSummary([FromBody] PresenceSummaryRequest? request, CancellationToken ct)
+    {
+        request ??= new PresenceSummaryRequest(null);
+        if (request.UserIds is null && !User.IsInRole("Admin"))
+        {
+            var failure = Result<PresenceSummaryResponse>.Failure(
+                new Error(Error.Codes.Forbidden, "Global presence summary requires admin role."));
+            return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
+        }
+
+        var result = await _reader
+            .GetSummaryAsync(request, ct)
+            .ConfigureAwait(false);
+
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+}

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -146,6 +146,36 @@ public static class ServiceCollectionExtensions
                 });
             });
 
+            options.AddPolicy("PresenceAdminReads", httpContext =>
+            {
+                var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
+
+                return RateLimitPartition.GetTokenBucketLimiter(userKey, _ => new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = 60,
+                    TokensPerPeriod = 60,
+                    ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                });
+            });
+
+            options.AddPolicy("PresenceBatchReads", httpContext =>
+            {
+                var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();
+
+                return RateLimitPartition.GetTokenBucketLimiter(userKey, _ => new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = 200,
+                    TokensPerPeriod = 200,
+                    ReplenishmentPeriod = TimeSpan.FromMinutes(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                });
+            });
+
             options.AddPolicy("FriendInvite", httpContext =>
             {
                 var userKey = httpContext.User.GetUserId()?.ToString() ?? Guid.Empty.ToString();

--- a/WebAPI/appsettings.Development.json
+++ b/WebAPI/appsettings.Development.json
@@ -75,7 +75,12 @@
   },
   "Presence": {
     "TtlSeconds": 60,
-    "HeartbeatSeconds": 30
+    "HeartbeatSeconds": 30,
+    "KeyPrefix": "sg",
+    "GraceSeconds": 5,
+    "MaxBatchSize": 200,
+    "DefaultPageSize": 100,
+    "MaxPageSize": 500
   },
   "Chat": {
     "HistoryMax": 200,

--- a/WebAPI/appsettings.json
+++ b/WebAPI/appsettings.json
@@ -8,7 +8,12 @@
   "AllowedHosts": "*",
   "Presence": {
     "TtlSeconds": 60,
-    "HeartbeatSeconds": 30
+    "HeartbeatSeconds": 30,
+    "KeyPrefix": "sg",
+    "GraceSeconds": 5,
+    "MaxBatchSize": 200,
+    "DefaultPageSize": 100,
+    "MaxPageSize": 500
   },
   "Redis": {
     "ConnectionString": "localhost:6379"


### PR DESCRIPTION
## Summary
- add a Redis-backed IPresenceReader with cursor pagination, batch lookups, and summary reporting wired into DI
- expose presence DTOs and an authorized PresenceController plus rate-limit policies and configuration for key prefixes and limits
- pipeline presence heartbeats through Redis sorted-set indexing and expand automated tests for heartbeat, reader, and summary scenarios

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f3372526cc832da2d328069c89029b