### PR TITLE
Add billing options, wallet APIs, and VNPay safeguards

### DIFF
--- a/BusinessObjects/Common/Enums.cs
+++ b/BusinessObjects/Common/Enums.cs
@@ -11,7 +11,7 @@
     public enum TransactionDirection { In, Out }     // In: tiền vào ví, Out: tiền ra ví
     public enum TransactionMethod { Wallet, Card, Gateway }
     public enum TransactionStatus { Pending, Succeeded, Failed, Refunded, Disputed }
-    public enum PaymentPurpose { TopUp, EventTicket }
+    public enum PaymentPurpose { TopUp, EventTicket, WalletTopUp }
     public enum PaymentIntentStatus { RequiresPayment, Processing, Succeeded, Canceled }
     public enum BugStatus { Open, InProgress, Resolved, Rejected }
     public enum RoomJoinPolicy

--- a/DTOs/Wallets/WalletSummaryDto.cs
+++ b/DTOs/Wallets/WalletSummaryDto.cs
@@ -1,0 +1,5 @@
+namespace DTOs.Wallets;
+
+public sealed record WalletSummaryDto(
+    bool Exists,
+    long BalanceCents);

--- a/DTOs/Wallets/WalletTopUpRequestDto.cs
+++ b/DTOs/Wallets/WalletTopUpRequestDto.cs
@@ -1,0 +1,3 @@
+namespace DTOs.Wallets;
+
+public sealed record WalletTopUpRequestDto(long AmountCents);

--- a/Services/Common/DependencyInjection/DependencyInjection.cs
+++ b/Services/Common/DependencyInjection/DependencyInjection.cs
@@ -1,6 +1,7 @@
 ﻿using FluentValidation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Services.Configuration;
 using Services.Presence;
 using System.Reflection;
 
@@ -42,6 +43,12 @@ namespace Services.Common.DependencyInjection
                         .Validate(o => o.MaxBatchSize > 0, "Presence:MaxBatchSize must be positive")
                         .Validate(o => o.DefaultPageSize > 0, "Presence:DefaultPageSize must be positive")
                         .Validate(o => o.MaxPageSize >= o.DefaultPageSize, "Presence:MaxPageSize must be >= DefaultPageSize")
+                        .ValidateOnStart();
+                services.AddOptions<BillingOptions>()
+                        .Bind(configuration.GetSection(BillingOptions.SectionName))
+                        .Validate(o => o.EventCreationFeeCents >= 0, "Billing:EventCreationFeeCents must be >= 0")
+                        .Validate(o => o.MaxEventEscrowTopUpAmountCents > 0, "Billing:MaxEventEscrowTopUpAmountCents must be positive")
+                        .Validate(o => o.MaxWalletTopUpAmountCents > 0, "Billing:MaxWalletTopUpAmountCents must be positive")
                         .ValidateOnStart();
                 // KHÔNG đăng ký singleton .Value để giữ hot-reload
             }

--- a/Services/Configuration/BillingOptions.cs
+++ b/Services/Configuration/BillingOptions.cs
@@ -1,0 +1,29 @@
+namespace Services.Configuration;
+
+/// <summary>
+/// Billing configuration for platform fees and wallet limits.
+/// </summary>
+public sealed class BillingOptions
+{
+    public const string SectionName = "Billing";
+
+    /// <summary>
+    /// Event creation fee charged to organizers in VND cents.
+    /// </summary>
+    public long EventCreationFeeCents { get; set; } = 50_000;
+
+    /// <summary>
+    /// Optional platform user identifier used as the platform wallet owner.
+    /// </summary>
+    public Guid? PlatformUserId { get; set; }
+
+    /// <summary>
+    /// Maximum allowed escrow top-up amount in cents.
+    /// </summary>
+    public long MaxEventEscrowTopUpAmountCents { get; set; } = 50_000_000;
+
+    /// <summary>
+    /// Maximum allowed direct wallet top-up amount in cents.
+    /// </summary>
+    public long MaxWalletTopUpAmountCents { get; set; } = 20_000_000;
+}

--- a/Services/GlobalUsing.cs
+++ b/Services/GlobalUsing.cs
@@ -19,6 +19,7 @@ global using DTOs.Rooms;
 global using DTOs.Events;
 global using DTOs.Common;
 global using DTOs.Registrations;
+global using DTOs.Wallets;
 global using DTOs.Games;
 global using Repositories.Interfaces;
 global using Repositories.Persistence;

--- a/Services/Implementations/WalletReadService.cs
+++ b/Services/Implementations/WalletReadService.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Options;
+using Services.Configuration;
+
+namespace Services.Implementations;
+
+/// <summary>
+/// Read-only wallet queries for end users and platform administrators.
+/// </summary>
+public sealed class WalletReadService : IWalletReadService
+{
+    private readonly IWalletRepository _walletRepository;
+    private readonly BillingOptions _billingOptions;
+
+    public WalletReadService(IWalletRepository walletRepository, IOptionsSnapshot<BillingOptions> billingOptions)
+    {
+        _walletRepository = walletRepository ?? throw new ArgumentNullException(nameof(walletRepository));
+        _billingOptions = billingOptions?.Value ?? throw new ArgumentNullException(nameof(billingOptions));
+    }
+
+    public async Task<Result<WalletSummaryDto>> GetAsync(Guid userId, CancellationToken ct = default)
+    {
+        var wallet = await _walletRepository.GetByUserIdAsync(userId, ct).ConfigureAwait(false);
+        var summary = new WalletSummaryDto(wallet is not null, wallet?.BalanceCents ?? 0);
+        return Result<WalletSummaryDto>.Success(summary);
+    }
+
+    public async Task<Result<WalletSummaryDto>> GetPlatformWalletAsync(CancellationToken ct = default)
+    {
+        if (!_billingOptions.PlatformUserId.HasValue || _billingOptions.PlatformUserId.Value == Guid.Empty)
+        {
+            return Result<WalletSummaryDto>.Failure(new Error(Error.Codes.Unexpected, "Platform wallet is not configured."));
+        }
+
+        var wallet = await _walletRepository.GetByUserIdAsync(_billingOptions.PlatformUserId.Value, ct).ConfigureAwait(false);
+        var summary = new WalletSummaryDto(wallet is not null, wallet?.BalanceCents ?? 0);
+        return Result<WalletSummaryDto>.Success(summary);
+    }
+}

--- a/Services/Interfaces/IPaymentService.cs
+++ b/Services/Interfaces/IPaymentService.cs
@@ -5,6 +5,7 @@ namespace Services.Interfaces;
 public interface IPaymentService
 {
     Task<Result<Guid>> CreateTopUpIntentAsync(Guid organizerId, Guid eventId, long amountCents, CancellationToken ct = default);
+    Task<Result<Guid>> CreateWalletTopUpIntentAsync(Guid userId, long amountCents, CancellationToken ct = default);
     Task<Result> ConfirmAsync(Guid userId, Guid paymentIntentId, CancellationToken ct = default);
     Task<Result<string>> CreateHostedCheckoutUrlAsync(Guid userId, Guid paymentIntentId, string? returnUrl, string clientIp, CancellationToken ct = default);
     Task<Result> HandleVnPayCallbackAsync(IQueryCollection query, IFormCollection? form, CancellationToken ct = default);

--- a/Services/Interfaces/IWalletReadService.cs
+++ b/Services/Interfaces/IWalletReadService.cs
@@ -1,0 +1,7 @@
+namespace Services.Interfaces;
+
+public interface IWalletReadService
+{
+    Task<Result<WalletSummaryDto>> GetAsync(Guid userId, CancellationToken ct = default);
+    Task<Result<WalletSummaryDto>> GetPlatformWalletAsync(CancellationToken ct = default);
+}

--- a/WebAPI/Controllers/WalletController.cs
+++ b/WebAPI/Controllers/WalletController.cs
@@ -1,0 +1,79 @@
+using DTOs.Wallets;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace WebAPI.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+public sealed class WalletController : ControllerBase
+{
+    private readonly IWalletReadService _walletReadService;
+    private readonly IPaymentService _paymentService;
+
+    public WalletController(IWalletReadService walletReadService, IPaymentService paymentService)
+    {
+        _walletReadService = walletReadService ?? throw new ArgumentNullException(nameof(walletReadService));
+        _paymentService = paymentService ?? throw new ArgumentNullException(nameof(paymentService));
+    }
+
+    [HttpGet]
+    [EnableRateLimiting("ReadsLight")]
+    [ProducesResponseType(typeof(WalletSummaryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> Get(CancellationToken ct)
+    {
+        var userId = User.GetUserId();
+        if (!userId.HasValue)
+        {
+            return this.ToActionResult(Result<WalletSummaryDto>.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        var result = await _walletReadService.GetAsync(userId.Value, ct).ConfigureAwait(false);
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+
+    [HttpGet("platform")]
+    [Authorize(Roles = "Admin")]
+    [EnableRateLimiting("ReadsLight")]
+    [ProducesResponseType(typeof(WalletSummaryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> GetPlatformWallet(CancellationToken ct)
+    {
+        var result = await _walletReadService.GetPlatformWalletAsync(ct).ConfigureAwait(false);
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+
+    [HttpPost("topups")]
+    [EnableRateLimiting("PaymentsWrite")]
+    [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> CreateTopUp([FromBody] WalletTopUpRequestDto? request, CancellationToken ct)
+    {
+        if (request is null)
+        {
+            return this.ToActionResult(Result<Guid>.Failure(new Error(Error.Codes.Validation, "Request body is required.")));
+        }
+
+        var userId = User.GetUserId();
+        if (!userId.HasValue)
+        {
+            return this.ToActionResult(Result<Guid>.Failure(new Error(Error.Codes.Unauthorized, "User identity is required.")));
+        }
+
+        var result = await _paymentService.CreateWalletTopUpIntentAsync(userId.Value, request.AmountCents, ct).ConfigureAwait(false);
+        return this.ToActionResult(result, v => new { paymentIntentId = v }, StatusCodes.Status201Created);
+    }
+}

--- a/WebAPI/GlobalUsing.cs
+++ b/WebAPI/GlobalUsing.cs
@@ -13,6 +13,7 @@ global using DTOs.Roles.Requests;
 global using DTOs.Rooms;
 global using DTOs.Users;
 global using DTOs.Users.Requests;
+global using DTOs.Wallets;
 global using Microsoft.AspNetCore.DataProtection;
 global using Repositories.DependencyInjection;
 global using Services.Common.Auth;

--- a/WebAPI/appsettings.Development.json
+++ b/WebAPI/appsettings.Development.json
@@ -96,6 +96,11 @@
   "Redis": {
     "ConnectionString": "localhost:6379"
   },
+  "Billing": {
+    "EventCreationFeeCents": 50000,
+    "MaxEventEscrowTopUpAmountCents": 50000000,
+    "MaxWalletTopUpAmountCents": 20000000
+  },
   "VnPay": {
     "TmnCode": "<from user-secrets>",
     "HashSecret": "<from user-secrets>",

--- a/WebAPI/appsettings.json
+++ b/WebAPI/appsettings.json
@@ -17,5 +17,10 @@
   },
   "Redis": {
     "ConnectionString": "localhost:6379"
+  },
+  "Billing": {
+    "EventCreationFeeCents": 50000,
+    "MaxEventEscrowTopUpAmountCents": 50000000,
+    "MaxWalletTopUpAmountCents": 20000000
   }
 }


### PR DESCRIPTION
## Summary
- enforce the configurable event creation fee during organizer event creation, including platform wallet credits and ledger metadata
- extend payment processing with wallet top-up intents, VNPay return URL allow-listing, and richer transaction metadata
- add wallet read APIs plus billing configuration defaults for shared and development settings

## Testing
- `dotnet build StudentGamerHub.sln` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f582ece6c0832d850529d25780b912