### PR TITLE
Prevent development seeder from populating runtime entities

### DIFF
--- a/Repositories/Persistence/Seeding/AppSeeder.cs
+++ b/Repositories/Persistence/Seeding/AppSeeder.cs
@@ -427,6 +427,7 @@ public sealed class AppSeeder : IAppSeeder
     {
         var communities = await _db.Communities
             .AsNoTracking()
+            .Where(c => c.CreatedBy == null)
             .Select(c => c.Id)
             .ToListAsync(ct);
         var games = await _db.Games
@@ -480,6 +481,7 @@ public sealed class AppSeeder : IAppSeeder
     {
         var communities = await _db.Communities
             .AsNoTracking()
+            .Where(c => c.CreatedBy == null)
             .Select(c => new { c.Id, c.Name, c.CreatedAtUtc })
             .ToListAsync(ct);
         if (communities.Count == 0) return;
@@ -488,6 +490,7 @@ public sealed class AppSeeder : IAppSeeder
 
         var existingByCommunity = await _db.Clubs
             .AsNoTracking()
+            .Where(c => c.CreatedBy == null)
             .GroupBy(c => c.CommunityId)
             .ToDictionaryAsync(
                 g => g.Key,
@@ -538,6 +541,7 @@ public sealed class AppSeeder : IAppSeeder
     {
         var clubs = await _db.Clubs
             .AsNoTracking()
+            .Where(c => c.CreatedBy == null)
             .Select(c => new { c.Id, c.CreatedAtUtc })
             .ToListAsync(ct);
         if (clubs.Count == 0) return;
@@ -546,6 +550,7 @@ public sealed class AppSeeder : IAppSeeder
 
         var existingByClub = await _db.Rooms
             .AsNoTracking()
+            .Where(r => r.CreatedBy == null)
             .GroupBy(r => r.ClubId)
             .ToDictionaryAsync(
                 g => g.Key,
@@ -600,6 +605,7 @@ public sealed class AppSeeder : IAppSeeder
     {
         var rooms = await _db.Rooms
             .AsNoTracking()
+            .Where(r => r.CreatedBy == null)
             .Select(r => new { r.Id, r.CreatedAtUtc })
             .ToListAsync(ct);
 

--- a/Tests/Services.Communities.Tests/CascadeSeedingGuardTests.cs
+++ b/Tests/Services.Communities.Tests/CascadeSeedingGuardTests.cs
@@ -1,0 +1,214 @@
+using BusinessObjects;
+using BusinessObjects.Common.Results;
+using DTOs.Clubs;
+using DTOs.Communities;
+using DTOs.Rooms;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Repositories.Implements;
+using Repositories.Persistence;
+using Repositories.Persistence.Seeding;
+using Repositories.WorkSeeds.Implements;
+using Repositories.WorkSeeds.Interfaces;
+using Services.Implementations;
+using Xunit;
+
+namespace Services.Communities.Tests;
+
+public sealed class CascadeSeedingGuardTests
+{
+    [Fact]
+    public async Task CreateCommunity_ShouldNotGainSeederClubs()
+    {
+        await using var ctx = await CascadeTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+        var request = new CommunityCreateRequestDto(null, "Test Community", null, null, true);
+
+        var created = await ctx.CommunityService.CreateCommunityAsync(request, userId);
+        created.IsSuccess.Should().BeTrue();
+
+        await ctx.Seeder.SeedAsync();
+
+        var clubCount = await ctx.Db.Clubs
+            .CountAsync(c => c.CommunityId == created.Value!.Id);
+        clubCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateClub_ShouldNotGainSeederRooms()
+    {
+        await using var ctx = await CascadeTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+        var communityReq = new CommunityCreateRequestDto(null, "Club Parent", null, null, true);
+        var community = await ctx.CommunityService.CreateCommunityAsync(communityReq, userId);
+        community.IsSuccess.Should().BeTrue();
+
+        var clubReq = new ClubCreateRequestDto(community.Value!.Id, "My Club", null, true);
+        var club = await ctx.ClubService.CreateClubAsync(clubReq, userId);
+        club.IsSuccess.Should().BeTrue();
+
+        await ctx.Seeder.SeedAsync();
+
+        var roomCount = await ctx.Db.Rooms
+            .CountAsync(r => r.ClubId == club.Value!.Id);
+        roomCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateRoom_ShouldNotGainSeederMembers()
+    {
+        await using var ctx = await CascadeTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+        var communityReq = new CommunityCreateRequestDto(null, "Room Parent", null, null, true);
+        var community = await ctx.CommunityService.CreateCommunityAsync(communityReq, userId);
+        community.IsSuccess.Should().BeTrue();
+
+        var clubReq = new ClubCreateRequestDto(community.Value!.Id, "Room Club", null, true);
+        var club = await ctx.ClubService.CreateClubAsync(clubReq, userId);
+        club.IsSuccess.Should().BeTrue();
+
+        var roomReq = new RoomCreateRequestDto(club.Value!.Id, "Focus Room", null, RoomJoinPolicy.Open, null, null);
+        var room = await ctx.RoomService.CreateRoomAsync(roomReq, userId);
+        room.IsSuccess.Should().BeTrue();
+
+        await ctx.Seeder.SeedAsync();
+
+        var memberCount = await ctx.Db.RoomMembers
+            .CountAsync(rm => rm.RoomId == room.Value!.Id);
+        memberCount.Should().Be(1);
+    }
+
+    private sealed class CascadeTestContext : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly IGenericUnitOfWork _uow;
+        private readonly UserManager<User> _userManager;
+
+        public required AppDbContext Db { get; init; }
+        public required CommunityService CommunityService { get; init; }
+        public required ClubService ClubService { get; init; }
+        public required RoomService RoomService { get; init; }
+        public required AppSeeder Seeder { get; init; }
+
+        private CascadeTestContext(SqliteConnection connection, IGenericUnitOfWork uow, UserManager<User> userManager)
+        {
+            _connection = connection;
+            _uow = uow;
+            _userManager = userManager;
+        }
+
+        public static async Task<CascadeTestContext> CreateAsync()
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var db = new AppDbContext(options);
+            await db.Database.EnsureCreatedAsync();
+
+            var services = new ServiceCollection().BuildServiceProvider();
+            var factory = new RepositoryFactory(db, services);
+            var uow = new UnitOfWork(db, factory);
+
+            var communityQuery = new CommunityQueryRepository(db);
+            var communityCommand = new CommunityCommandRepository(db);
+            var clubQuery = new ClubQueryRepository(db);
+            var clubCommand = new ClubCommandRepository(db);
+            var roomQuery = new RoomQueryRepository(db);
+            var roomCommand = new RoomCommandRepository(db);
+
+            var communityService = new CommunityService(
+                uow,
+                communityQuery,
+                communityCommand,
+                clubQuery,
+                clubCommand,
+                roomQuery,
+                roomCommand);
+
+            var clubService = new ClubService(
+                uow,
+                clubQuery,
+                clubCommand,
+                communityQuery,
+                roomQuery,
+                roomCommand);
+
+            var roomService = new RoomService(
+                uow,
+                roomQuery,
+                roomCommand,
+                clubQuery,
+                new PasswordHasher<Room>());
+
+            var gameRepository = new GameRepository(db);
+            var userGameRepository = new UserGameRepository(db);
+
+            var seedOptions = Options.Create(new SeedOptions
+            {
+                Run = true,
+                ApplyMigrations = false,
+                AllowInProduction = true,
+                Roles = Array.Empty<string>(),
+                Admin = new SeedOptions.AdminOptions(),
+                ComprehensiveSeeding = new SeedOptions.ComprehensiveOptions
+                {
+                    SeedSampleUsers = false,
+                    SeedCommunities = false,
+                    SeedClubsAndRooms = true,
+                    SeedEvents = false,
+                    SeedWalletsAndTransactions = false,
+                    SeedFriendships = false,
+                    SeedGifts = false,
+                    SeedBugReports = false
+                }
+            });
+
+            var userStore = new UserStore<User, Role, AppDbContext, Guid>(db);
+            var userManager = new UserManager<User>(
+                userStore,
+                null,
+                new PasswordHasher<User>(),
+                Array.Empty<IUserValidator<User>>(),
+                Array.Empty<IPasswordValidator<User>>(),
+                new UpperInvariantLookupNormalizer(),
+                new IdentityErrorDescriber(),
+                null,
+                NullLogger<UserManager<User>>.Instance);
+
+            var seeder = new AppSeeder(
+                db,
+                gameRepository,
+                userGameRepository,
+                uow,
+                NullLogger<AppSeeder>.Instance,
+                userManager,
+                seedOptions);
+
+            return new CascadeTestContext(connection, uow, userManager)
+            {
+                Db = db,
+                CommunityService = communityService,
+                ClubService = clubService,
+                RoomService = roomService,
+                Seeder = seeder
+            };
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _uow.DisposeAsync();
+            _userManager.Dispose();
+            await Db.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+}

--- a/cascade-audit.md
+++ b/cascade-audit.md
@@ -1,0 +1,34 @@
+# Cascade Audit Report
+
+## Summary
+- Identified that the development `AppSeeder` was enriching every community/club/room in the database regardless of origin, which caused bulk child creation whenever a new aggregate was inserted during a seeding run. 【F:Repositories/Persistence/Seeding/AppSeeder.cs†L426-L691】
+- Added guard clauses so the seeder now scopes itself to seed-owned rows (`CreatedBy == null`) and leaves user-created entities untouched. 【F:Repositories/Persistence/Seeding/AppSeeder.cs†L428-L609】
+- Introduced integration tests that simulate the create flows, execute the seeder afterwards, and assert that no unintended children appear. 【F:Tests/Services.Communities.Tests/CascadeSeedingGuardTests.cs†L23-L214】
+
+## Reproduction
+1. Start the WebAPI with seeding enabled (default `Seed:Run = true`).
+2. Issue `POST /api/communities` while the hosted `DbInitializerHostedService` is still executing `AppSeeder.SeedAsync`.
+3. Observe that the community obtains 1-3 random clubs because `SeedClubsAsync` pulls every community from `_db.Communities` without filtering. 【F:Repositories/Persistence/Seeding/AppSeeder.cs†L480-L531】
+4. Repeat for `POST /api/clubs` or `POST /api/rooms`; `SeedRoomsAsync` and `SeedRoomMembersAsync` likewise attach rooms and members to the just-created records. 【F:Repositories/Persistence/Seeding/AppSeeder.cs†L540-L691】
+
+## Root Causes
+1. **Seeder lacks ownership filter** – `SeedCommunityGamesAsync`, `SeedClubsAsync`, `SeedRoomsAsync`, and `SeedRoomMembersAsync` select *all* rows, so user-created parents are enriched with sample data whenever the seeder runs. 【F:Repositories/Persistence/Seeding/AppSeeder.cs†L428-L609】
+2. **Seeder executed during live traffic** – `DbInitializerHostedService` runs on startup; requests made before completion enter the same transaction scope, exposing the above logic. (No code change required once filtering is applied.)
+
+## Fixes
+- Filter every seeding phase that mutates child collections to `CreatedBy == null`, which is true for seed data but false for runtime creations. 【F:Repositories/Persistence/Seeding/AppSeeder.cs†L428-L609】
+- Leave existing indexes intact; they already enforce uniqueness for clubs, rooms, and memberships. 【F:Repositories/Persistence/AppDbContext.cs†L272-L354】
+- Added regression tests covering community, club, and room create flows with a post-create seeder execution. 【F:Tests/Services.Communities.Tests/CascadeSeedingGuardTests.cs†L23-L214】
+
+## Database Constraints
+- Clubs enforce `UNIQUE(CommunityId, Name)`. 【F:Repositories/Persistence/AppDbContext.cs†L276-L287】
+- Rooms enforce `UNIQUE(ClubId, Name)`. 【F:Repositories/Persistence/AppDbContext.cs†L305-L327】
+- Room members enforce `UNIQUE(RoomId, UserId)` and supporting status indexes. 【F:Repositories/Persistence/AppDbContext.cs†L329-L354】
+
+## Tests Added
+- `CascadeSeedingGuardTests.CreateCommunity_ShouldNotGainSeederClubs`.
+- `CascadeSeedingGuardTests.CreateClub_ShouldNotGainSeederRooms`.
+- `CascadeSeedingGuardTests.CreateRoom_ShouldNotGainSeederMembers`. 【F:Tests/Services.Communities.Tests/CascadeSeedingGuardTests.cs†L23-L214】
+
+## Verification
+- .NET SDK is not available in the execution environment, so automated test execution was not possible. Manual code reasoning and the new tests capture the regression scenarios for future runs.


### PR DESCRIPTION
## Summary
- scope the AppSeeder community/club/room phases to seed-owned rows so it no longer decorates live entities
- add regression integration tests that create communities/clubs/rooms, run the seeder, and assert no extra children appear
- document the cascade investigation in cascade-audit.md

## Testing
- not run (dotnet SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f880bed144832da79f7016e3294f55