### PR TITLE
Add membership tree read endpoints

### DIFF
--- a/Services/Common/Mapping/MembershipsProfile.cs
+++ b/Services/Common/Mapping/MembershipsProfile.cs
@@ -1,0 +1,120 @@
+using Services.DTOs.Memberships;
+
+namespace Services.Common.Mapping;
+
+public static class MembershipsProfile
+{
+    public static MembershipTreeMutableDto ToMutableDto(this MembershipTreeProjection projection)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+
+        var dto = new MembershipTreeMutableDto
+        {
+            Overview = new MembershipTreeMutableDto.OverviewMutable
+            {
+                CommunityCount = projection.Overview.CommunityCount,
+                ClubCount = projection.Overview.ClubCount,
+                RoomCount = projection.Overview.RoomCount
+            }
+        };
+
+        dto.Communities = projection.Communities
+            .Select(community => new MembershipTreeMutableDto.CommunityNode
+            {
+                CommunityId = community.CommunityId,
+                CommunityName = community.CommunityName,
+                Clubs = community.Clubs
+                    .Select(club => new MembershipTreeMutableDto.ClubNode
+                    {
+                        ClubId = club.ClubId,
+                        ClubName = club.ClubName,
+                        Rooms = club.Rooms
+                            .Select(room => new MembershipTreeMutableDto.RoomNode
+                            {
+                                RoomId = room.RoomId,
+                                RoomName = room.RoomName
+                            })
+                            .ToList()
+                    })
+                    .ToList()
+            })
+            .ToList();
+
+        return dto;
+    }
+
+    public static MembershipTreeImmutableDto ToImmutableDto(this MembershipTreeProjection projection)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+
+        var communities = projection.Communities
+            .Select(community => new MembershipTreeImmutableDto.CommunityNode(
+                community.CommunityId,
+                community.CommunityName,
+                community.Clubs
+                    .Select(club => new MembershipTreeImmutableDto.ClubNode(
+                        club.ClubId,
+                        club.ClubName,
+                        club.Rooms
+                            .Select(room => new MembershipTreeImmutableDto.RoomNode(room.RoomId, room.RoomName))
+                            .ToList()))
+                    .ToList()))
+            .ToList();
+
+        var overview = new MembershipTreeImmutableDto.OverviewImmutable(
+            projection.Overview.CommunityCount,
+            projection.Overview.ClubCount,
+            projection.Overview.RoomCount);
+
+        return new MembershipTreeImmutableDto(communities, overview);
+    }
+
+    public static MembershipTreeHybridDto ToHybridDto(this MembershipTreeProjection projection)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+
+        var communities = projection.Communities
+            .Select(community => new MembershipTreeHybridDto.CommunityNode(
+                community.CommunityId,
+                community.CommunityName,
+                community.Clubs
+                    .Select(club => new MembershipTreeHybridDto.ClubNode(
+                        club.ClubId,
+                        club.ClubName,
+                        club.Rooms
+                            .Select(room => new MembershipTreeHybridDto.RoomNode(room.RoomId, room.RoomName))
+                            .ToList()))
+                    .ToList()))
+            .ToList();
+
+        var overview = new MembershipTreeHybridDto.OverviewHybrid(
+            projection.Overview.CommunityCount,
+            projection.Overview.ClubCount,
+            projection.Overview.RoomCount);
+
+        return MembershipTreeHybridDto.FromBuilder(communities, overview);
+    }
+}
+
+internal sealed record MembershipTreeProjection(
+    IReadOnlyList<MembershipCommunityProjection> Communities,
+    MembershipOverviewProjection Overview);
+
+internal sealed record MembershipCommunityProjection(
+    Guid CommunityId,
+    string? CommunityName,
+    IReadOnlyList<MembershipClubProjection> Clubs);
+
+internal sealed record MembershipClubProjection(
+    Guid ClubId,
+    string? ClubName,
+    IReadOnlyList<MembershipRoomProjection> Rooms);
+
+internal sealed record MembershipRoomProjection(
+    Guid RoomId,
+    string? RoomName);
+
+internal sealed record MembershipOverviewProjection(
+    int CommunityCount,
+    int ClubCount,
+    int RoomCount);

--- a/Services/DTOs/Memberships/MembershipTreeHybridDto.cs
+++ b/Services/DTOs/Memberships/MembershipTreeHybridDto.cs
@@ -1,0 +1,19 @@
+namespace Services.DTOs.Memberships;
+
+public sealed class MembershipTreeHybridDto
+{
+    public IReadOnlyList<CommunityNode> Communities { get; private init; } = Array.Empty<CommunityNode>();
+    public OverviewHybrid Overview { get; private init; } = new(0, 0, 0);
+
+    public sealed record OverviewHybrid(int CommunityCount, int ClubCount, int RoomCount);
+    public sealed record CommunityNode(Guid CommunityId, string? CommunityName, IReadOnlyList<ClubNode> Clubs);
+    public sealed record ClubNode(Guid ClubId, string? ClubName, IReadOnlyList<RoomNode> Rooms);
+    public sealed record RoomNode(Guid RoomId, string? RoomName);
+
+    public static MembershipTreeHybridDto FromBuilder(List<CommunityNode> communities, OverviewHybrid overview)
+        => new()
+        {
+            Communities = communities,
+            Overview = overview
+        };
+}

--- a/Services/DTOs/Memberships/MembershipTreeImmutableDto.cs
+++ b/Services/DTOs/Memberships/MembershipTreeImmutableDto.cs
@@ -1,0 +1,12 @@
+namespace Services.DTOs.Memberships;
+
+public sealed record MembershipTreeImmutableDto(
+    IReadOnlyList<CommunityNode> Communities,
+    OverviewImmutable Overview
+)
+{
+    public sealed record CommunityNode(Guid CommunityId, string? CommunityName, IReadOnlyList<ClubNode> Clubs);
+    public sealed record ClubNode(Guid ClubId, string? ClubName, IReadOnlyList<RoomNode> Rooms);
+    public sealed record RoomNode(Guid RoomId, string? RoomName);
+    public sealed record OverviewImmutable(int CommunityCount, int ClubCount, int RoomCount);
+}

--- a/Services/DTOs/Memberships/MembershipTreeMutableDto.cs
+++ b/Services/DTOs/Memberships/MembershipTreeMutableDto.cs
@@ -1,0 +1,34 @@
+namespace Services.DTOs.Memberships;
+
+public sealed class MembershipTreeMutableDto
+{
+    public List<CommunityNode> Communities { get; set; } = new();
+    public OverviewMutable Overview { get; set; } = new();
+
+    public sealed class CommunityNode
+    {
+        public Guid CommunityId { get; set; }
+        public string? CommunityName { get; set; }
+        public List<ClubNode> Clubs { get; set; } = new();
+    }
+
+    public sealed class ClubNode
+    {
+        public Guid ClubId { get; set; }
+        public string? ClubName { get; set; }
+        public List<RoomNode> Rooms { get; set; } = new();
+    }
+
+    public sealed class RoomNode
+    {
+        public Guid RoomId { get; set; }
+        public string? RoomName { get; set; }
+    }
+
+    public sealed class OverviewMutable
+    {
+        public int CommunityCount { get; set; }
+        public int ClubCount { get; set; }
+        public int RoomCount { get; set; }
+    }
+}

--- a/Services/Implementations/Memberships/MembershipReadService.cs
+++ b/Services/Implementations/Memberships/MembershipReadService.cs
@@ -1,0 +1,158 @@
+using Microsoft.EntityFrameworkCore;
+using Services.DTOs.Memberships;
+
+namespace Services.Implementations.Memberships;
+
+public sealed class MembershipReadService : IMembershipReadService
+{
+    private readonly AppDbContext _db;
+
+    public MembershipReadService(AppDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<Result<MembershipTreeHybridDto>> GetMyMembershipTreeAsync(Guid userId, CancellationToken ct = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            return Result<MembershipTreeHybridDto>.Failure(
+                new Error(Error.Codes.Validation, "UserId is required."));
+        }
+
+        var communityRows = await _db.CommunityMembers
+            .AsNoTracking()
+            .Where(cm => cm.UserId == userId)
+            .Select(cm => new CommunityMembershipRow(cm.CommunityId, cm.Community!.Name))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var clubRows = await _db.ClubMembers
+            .AsNoTracking()
+            .Where(cm => cm.UserId == userId)
+            .Select(cm => new ClubMembershipRow(
+                cm.ClubId,
+                cm.Club!.Name,
+                cm.Club!.CommunityId,
+                cm.Club!.Community!.Name))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var roomRows = await _db.RoomMembers
+            .AsNoTracking()
+            .Where(rm => rm.UserId == userId && rm.Status == RoomMemberStatus.Approved)
+            .Select(rm => new RoomMembershipRow(
+                rm.RoomId,
+                rm.Room!.Name,
+                rm.Room!.ClubId,
+                rm.Room!.Club!.Name,
+                rm.Room!.Club!.CommunityId,
+                rm.Room!.Club!.Community!.Name))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var communityNames = new Dictionary<Guid, string?>();
+        foreach (var row in communityRows)
+        {
+            UpdateCommunityName(communityNames, row.CommunityId, row.CommunityName);
+        }
+
+        var clubMap = new Dictionary<Guid, ClubInfo>();
+        foreach (var row in clubRows)
+        {
+            UpdateCommunityName(communityNames, row.CommunityId, row.CommunityName);
+            clubMap[row.ClubId] = new ClubInfo(row.ClubId, row.ClubName, row.CommunityId);
+        }
+
+        foreach (var row in roomRows)
+        {
+            UpdateCommunityName(communityNames, row.CommunityId, row.CommunityName);
+            if (!clubMap.ContainsKey(row.ClubId))
+            {
+                clubMap[row.ClubId] = new ClubInfo(row.ClubId, row.ClubName, row.CommunityId);
+            }
+        }
+
+        var roomsByClub = roomRows
+            .GroupBy(r => r.ClubId)
+            .ToDictionary(
+                g => g.Key,
+                g => g
+                    .OrderBy(r => r.RoomName ?? string.Empty)
+                    .ThenBy(r => r.RoomId)
+                    .Select(r => new MembershipRoomProjection(r.RoomId, r.RoomName))
+                    .ToList() as IReadOnlyList<MembershipRoomProjection>);
+
+        var clubsByCommunity = clubMap.Values
+            .GroupBy(c => c.CommunityId)
+            .ToDictionary(
+                g => g.Key,
+                g => g
+                    .OrderBy(c => c.ClubName ?? string.Empty)
+                    .ThenBy(c => c.ClubId)
+                    .Select(c =>
+                    {
+                        var rooms = roomsByClub.TryGetValue(c.ClubId, out var roomList)
+                            ? roomList
+                            : Array.Empty<MembershipRoomProjection>();
+                        return new MembershipClubProjection(c.ClubId, c.ClubName, rooms);
+                    })
+                    .ToList() as IReadOnlyList<MembershipClubProjection>);
+
+        var communities = communityNames
+            .Select(kvp =>
+            {
+                var clubs = clubsByCommunity.TryGetValue(kvp.Key, out var communityClubs)
+                    ? communityClubs
+                    : Array.Empty<MembershipClubProjection>();
+                return new MembershipCommunityProjection(kvp.Key, kvp.Value, clubs);
+            })
+            .OrderBy(c => c.CommunityName ?? string.Empty)
+            .ThenBy(c => c.CommunityId)
+            .ToList();
+
+        var overview = new MembershipOverviewProjection(
+            communities.Count,
+            clubMap.Count,
+            roomRows
+                .Select(r => r.RoomId)
+                .Distinct()
+                .Count());
+
+        var projection = new MembershipTreeProjection(communities, overview);
+        var dto = projection.ToHybridDto();
+
+        return Result<MembershipTreeHybridDto>.Success(dto);
+    }
+
+    private static void UpdateCommunityName(IDictionary<Guid, string?> map, Guid id, string? name)
+    {
+        if (map.TryGetValue(id, out var existing))
+        {
+            if (!string.IsNullOrWhiteSpace(existing))
+            {
+                return;
+            }
+        }
+
+        map[id] = name;
+    }
+
+    private sealed record CommunityMembershipRow(Guid CommunityId, string? CommunityName);
+
+    private sealed record ClubMembershipRow(
+        Guid ClubId,
+        string? ClubName,
+        Guid CommunityId,
+        string? CommunityName);
+
+    private sealed record RoomMembershipRow(
+        Guid RoomId,
+        string? RoomName,
+        Guid ClubId,
+        string? ClubName,
+        Guid CommunityId,
+        string? CommunityName);
+
+    private sealed record ClubInfo(Guid ClubId, string? ClubName, Guid CommunityId);
+}

--- a/Services/Interfaces/IMembershipReadService.cs
+++ b/Services/Interfaces/IMembershipReadService.cs
@@ -1,0 +1,8 @@
+using Services.DTOs.Memberships;
+
+namespace Services.Interfaces;
+
+public interface IMembershipReadService
+{
+    Task<Result<MembershipTreeHybridDto>> GetMyMembershipTreeAsync(Guid userId, CancellationToken ct = default);
+}

--- a/Tests/Services.Memberships.Tests/MembershipReadServiceTests.cs
+++ b/Tests/Services.Memberships.Tests/MembershipReadServiceTests.cs
@@ -1,0 +1,229 @@
+using BusinessObjects;
+using BusinessObjects.Common.Enums;
+using BusinessObjects.Common.Results;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Services.DTOs.Memberships;
+using Services.Implementations.Memberships;
+using Xunit;
+
+namespace Services.Memberships.Tests;
+
+public sealed class MembershipReadServiceTests
+{
+    [Fact]
+    public async Task GetMyMembershipTreeAsync_ShouldReturnHierarchyForJoinedEntities()
+    {
+        await using var ctx = await MembershipReadServiceTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+        ctx.Db.Users.Add(CreateUser(userId));
+
+        var alphaCommunity = CreateCommunity("Alpha Community", userId);
+        var betaCommunity = CreateCommunity("Beta Community", userId);
+        ctx.Db.Communities.AddRange(alphaCommunity, betaCommunity);
+
+        var arcadeClub = CreateClub(alphaCommunity.Id, "Arcade Club", userId);
+        var boardClub = CreateClub(alphaCommunity.Id, "Board Club", userId);
+        var betaClub = CreateClub(betaCommunity.Id, "Beta Club", userId);
+        ctx.Db.Clubs.AddRange(arcadeClub, boardClub, betaClub);
+
+        var arcadeRoom = CreateRoom(arcadeClub.Id, "Arcade Room", userId);
+        var arcadeRoomPending = CreateRoom(arcadeClub.Id, "Arcade Pending", userId);
+        var boardRoom = CreateRoom(boardClub.Id, "Board Room", userId);
+        ctx.Db.Rooms.AddRange(arcadeRoom, arcadeRoomPending, boardRoom);
+
+        ctx.Db.CommunityMembers.AddRange(
+            CreateCommunityMember(alphaCommunity.Id, userId),
+            CreateCommunityMember(betaCommunity.Id, userId));
+
+        ctx.Db.ClubMembers.AddRange(
+            CreateClubMember(arcadeClub.Id, userId),
+            CreateClubMember(boardClub.Id, userId));
+
+        ctx.Db.RoomMembers.AddRange(
+            CreateRoomMember(arcadeRoom.Id, userId, RoomMemberStatus.Approved),
+            CreateRoomMember(arcadeRoomPending.Id, userId, RoomMemberStatus.Pending));
+
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.GetMyMembershipTreeAsync(userId);
+
+        result.IsSuccess.Should().BeTrue();
+        var tree = result.Value.Should().NotBeNull().Subject;
+
+        tree.Overview.CommunityCount.Should().Be(2);
+        tree.Overview.ClubCount.Should().Be(2);
+        tree.Overview.RoomCount.Should().Be(1);
+
+        tree.Communities.Should().HaveCount(2);
+        tree.Communities.Select(c => c.CommunityName)
+            .Should().ContainInOrder("Alpha Community", "Beta Community");
+
+        var alphaNode = tree.Communities.First();
+        alphaNode.Clubs.Should().HaveCount(2);
+        alphaNode.Clubs.Select(c => c.ClubName)
+            .Should().ContainInOrder("Arcade Club", "Board Club");
+
+        var arcadeNode = alphaNode.Clubs.First();
+        arcadeNode.Rooms.Should().ContainSingle();
+        arcadeNode.Rooms[0].RoomName.Should().Be("Arcade Room");
+
+        var boardNode = alphaNode.Clubs.Skip(1).First();
+        boardNode.Rooms.Should().BeEmpty();
+
+        var betaNode = tree.Communities.Last();
+        betaNode.Clubs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetMyMembershipTreeAsync_ShouldReturnEmptyTree_WhenUserHasNoMemberships()
+    {
+        await using var ctx = await MembershipReadServiceTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+        ctx.Db.Users.Add(CreateUser(userId));
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.GetMyMembershipTreeAsync(userId);
+
+        result.IsSuccess.Should().BeTrue();
+        var tree = result.Value.Should().NotBeNull().Subject;
+        tree.Communities.Should().BeEmpty();
+        tree.Overview.CommunityCount.Should().Be(0);
+        tree.Overview.ClubCount.Should().Be(0);
+        tree.Overview.RoomCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetMyMembershipTreeAsync_ShouldFail_WhenUserIdIsEmpty()
+    {
+        await using var ctx = await MembershipReadServiceTestContext.CreateAsync();
+
+        var result = await ctx.Service.GetMyMembershipTreeAsync(Guid.Empty);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().NotBeNull();
+        result.Error!.Code.Should().Be(Error.Codes.Validation);
+    }
+
+    private static User CreateUser(Guid id) => new()
+    {
+        Id = id,
+        UserName = $"user-{id}",
+        NormalizedUserName = $"USER-{id}",
+        Email = $"{id}@example.com",
+        NormalizedEmail = $"{id}@EXAMPLE.COM",
+        SecurityStamp = Guid.NewGuid().ToString(),
+        ConcurrencyStamp = Guid.NewGuid().ToString(),
+        CreatedAtUtc = DateTime.UtcNow
+    };
+
+    private static Community CreateCommunity(string name, Guid createdBy) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = name,
+        Description = null,
+        IsPublic = true,
+        MembersCount = 0,
+        CreatedAtUtc = DateTime.UtcNow,
+        CreatedBy = createdBy
+    };
+
+    private static Club CreateClub(Guid communityId, string name, Guid createdBy) => new()
+    {
+        Id = Guid.NewGuid(),
+        CommunityId = communityId,
+        Name = name,
+        Description = null,
+        IsPublic = true,
+        MembersCount = 0,
+        CreatedAtUtc = DateTime.UtcNow,
+        CreatedBy = createdBy
+    };
+
+    private static Room CreateRoom(Guid clubId, string name, Guid createdBy) => new()
+    {
+        Id = Guid.NewGuid(),
+        ClubId = clubId,
+        Name = name,
+        Description = null,
+        JoinPolicy = RoomJoinPolicy.Open,
+        MembersCount = 0,
+        CreatedAtUtc = DateTime.UtcNow,
+        CreatedBy = createdBy
+    };
+
+    private static CommunityMember CreateCommunityMember(Guid communityId, Guid userId) => new()
+    {
+        Id = Guid.NewGuid(),
+        CommunityId = communityId,
+        UserId = userId,
+        Role = MemberRole.Member,
+        JoinedAt = DateTime.UtcNow,
+        CreatedAtUtc = DateTime.UtcNow,
+        CreatedBy = userId
+    };
+
+    private static ClubMember CreateClubMember(Guid clubId, Guid userId) => new()
+    {
+        Id = Guid.NewGuid(),
+        ClubId = clubId,
+        UserId = userId,
+        Role = MemberRole.Member,
+        JoinedAt = DateTime.UtcNow,
+        CreatedAtUtc = DateTime.UtcNow,
+        CreatedBy = userId
+    };
+
+    private static RoomMember CreateRoomMember(Guid roomId, Guid userId, RoomMemberStatus status) => new()
+    {
+        Id = Guid.NewGuid(),
+        RoomId = roomId,
+        UserId = userId,
+        Role = RoomRole.Member,
+        Status = status,
+        JoinedAt = DateTime.UtcNow,
+        CreatedAtUtc = DateTime.UtcNow,
+        CreatedBy = userId
+    };
+
+    private sealed class MembershipReadServiceTestContext : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+
+        public required AppDbContext Db { get; init; }
+        public required MembershipReadService Service { get; init; }
+
+        private MembershipReadServiceTestContext(SqliteConnection connection)
+        {
+            _connection = connection;
+        }
+
+        public static async Task<MembershipReadServiceTestContext> CreateAsync()
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var db = new AppDbContext(options);
+            await db.Database.EnsureCreatedAsync();
+
+            var service = new MembershipReadService(db);
+
+            return new MembershipReadServiceTestContext(connection)
+            {
+                Db = db,
+                Service = service
+            };
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+}

--- a/Tests/Services.Memberships.Tests/Services.Memberships.Tests.csproj
+++ b/Tests/Services.Memberships.Tests/Services.Memberships.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Services\Services.csproj" />
+  </ItemGroup>
+</Project>

--- a/WebAPI/Controllers/MembershipsController.cs
+++ b/WebAPI/Controllers/MembershipsController.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Services.DTOs.Memberships;
+using WebApi.Common;
+
+namespace WebAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public sealed class MembershipsController : ControllerBase
+{
+    private readonly IMembershipReadService _membershipReadService;
+
+    public MembershipsController(IMembershipReadService membershipReadService)
+    {
+        _membershipReadService = membershipReadService ?? throw new ArgumentNullException(nameof(membershipReadService));
+    }
+
+    [HttpGet("tree")]
+    [EnableRateLimiting("ReadsLight")]
+    [ProducesResponseType(typeof(MembershipTreeHybridDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult> GetMyMembershipTree(CancellationToken ct = default)
+    {
+        var userId = User.GetUserId();
+        if (userId is null)
+        {
+            var failure = Result<MembershipTreeHybridDto>.Failure(
+                new Error(Error.Codes.Unauthorized, "Authentication required."));
+            return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
+        }
+
+        var result = await _membershipReadService
+            .GetMyMembershipTreeAsync(userId.Value, ct)
+            .ConfigureAwait(false);
+
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+
+    [HttpGet("tree/{userId:guid}")]
+    [EnableRateLimiting("ReadsLight")]
+    [ProducesResponseType(typeof(MembershipTreeHybridDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult> GetMembershipTree(Guid userId, CancellationToken ct = default)
+    {
+        var callerId = User.GetUserId();
+        if (callerId is null)
+        {
+            var failure = Result<MembershipTreeHybridDto>.Failure(
+                new Error(Error.Codes.Unauthorized, "Authentication required."));
+            return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
+        }
+
+        if (callerId.Value != userId && !User.IsInRole("Admin"))
+        {
+            var failure = Result<MembershipTreeHybridDto>.Failure(
+                new Error(Error.Codes.Forbidden, "Only the owner or an admin may view this membership tree."));
+            return this.ToActionResult(failure, v => v, StatusCodes.Status200OK);
+        }
+
+        var result = await _membershipReadService
+            .GetMyMembershipTreeAsync(userId, ct)
+            .ConfigureAwait(false);
+
+        return this.ToActionResult(result, v => v, StatusCodes.Status200OK);
+    }
+}

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using StackExchange.Redis;
 using System.Threading.RateLimiting;
+using Services.Implementations.Memberships;
 using Services.Interfaces;
 
 namespace WebApi.Extensions;
@@ -427,6 +428,8 @@ public static class ServiceCollectionExtensions
 
         services.AddProblemDetails();
         services.AddExceptionHandler<AppExceptionHandler>();
+
+        services.AddScoped<IMembershipReadService, MembershipReadService>();
 
         // PayOS configuration and service
         services.Configure<Services.Configuration.PayOsConfig>(configuration.GetSection("PayOS"));


### PR DESCRIPTION
## Summary
- add hierarchical membership tree DTO variants and mapping profile
- implement a read-only membership tree service and Web API endpoints for current and target users
- register the read service and add coverage with a new memberships test suite

## Testing
- `dotnet test Tests/Services.Memberships.Tests/Services.Memberships.Tests.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f8e46da950832d9c557912025e3a91