### PR TITLE
Refine room member kick cascade

### DIFF
--- a/Tests/Services.Communities.Tests/CascadeSeedingGuardTests.cs
+++ b/Tests/Services.Communities.Tests/CascadeSeedingGuardTests.cs
@@ -147,7 +147,11 @@ public sealed class CascadeSeedingGuardTests
                 roomQuery,
                 roomCommand,
                 clubQuery,
-                new PasswordHasher<Room>());
+                clubCommand,
+                communityQuery,
+                communityCommand,
+                new PasswordHasher<Room>(),
+                NullLogger<RoomService>.Instance);
 
             var gameRepository = new GameRepository(db);
             var userGameRepository = new UserGameRepository(db);

--- a/Tests/Services.Memberships.Tests/MembershipReadServiceTests.cs
+++ b/Tests/Services.Memberships.Tests/MembershipReadServiceTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Services.DTOs.Memberships;
 using Services.Implementations;
 using Services.Implementations.Memberships;
@@ -289,12 +290,22 @@ public sealed class MembershipReadServiceTests
             var uow = new UnitOfWork(db, factory);
 
             var communityQuery = new CommunityQueryRepository(db);
+            var communityCommand = new CommunityCommandRepository(db);
             var clubQuery = new ClubQueryRepository(db);
             var clubCommand = new ClubCommandRepository(db);
             var roomQuery = new RoomQueryRepository(db);
             var roomCommand = new RoomCommandRepository(db);
             var clubService = new ClubService(uow, clubQuery, clubCommand, communityQuery, roomQuery, roomCommand);
-            var roomService = new RoomService(uow, roomQuery, roomCommand, clubQuery, new PasswordHasher<Room>());
+            var roomService = new RoomService(
+                uow,
+                roomQuery,
+                roomCommand,
+                clubQuery,
+                clubCommand,
+                communityQuery,
+                communityCommand,
+                new PasswordHasher<Room>(),
+                NullLogger<RoomService>.Instance);
             var membershipReadService = new MembershipReadService(db);
 
             return new MembershipScenarioTestContext(connection, uow)

--- a/Tests/Services.Rooms.Tests/RoomServiceTests.cs
+++ b/Tests/Services.Rooms.Tests/RoomServiceTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Repositories.Implements;
 using Repositories.Persistence;
 using Repositories.WorkSeeds.Implements;
@@ -106,6 +107,193 @@ public sealed class RoomServiceTests
         result.Error.Code.Should().Be(Error.Codes.Forbidden);
     }
 
+    [Fact]
+    public async Task KickRoomMemberAsync_ShouldCascadeRemoval_WhenOwnerRemovesApprovedMember()
+    {
+        await using var ctx = await RoomServiceTestContext.CreateAsync();
+        var ownerId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        var community = SeedCommunity(ctx, ownerId);
+        community.MembersCount = 2;
+        var club = SeedClub(ctx, community.Id, ownerId);
+        club.MembersCount = 2;
+        var room = SeedRoom(ctx, club.Id, ownerId, RoomJoinPolicy.Open, membersCount: 2);
+
+        SeedCommunityMember(ctx, community.Id, ownerId, MemberRole.Owner);
+        SeedCommunityMember(ctx, community.Id, targetId, MemberRole.Member);
+        SeedClubMember(ctx, club.Id, ownerId, MemberRole.Owner);
+        SeedClubMember(ctx, club.Id, targetId, MemberRole.Member);
+        SeedMember(ctx, room.Id, ownerId, RoomRole.Owner, RoomMemberStatus.Approved);
+        SeedMember(ctx, room.Id, targetId, RoomRole.Member, RoomMemberStatus.Approved);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.KickRoomMemberAsync(room.Id, targetId, ownerId);
+
+        result.IsSuccess.Should().BeTrue();
+
+        (await ctx.Db.RoomMembers.AnyAsync(m => m.RoomId == room.Id && m.UserId == targetId)).Should().BeFalse();
+        (await ctx.Db.ClubMembers.AnyAsync(m => m.ClubId == club.Id && m.UserId == targetId)).Should().BeFalse();
+        (await ctx.Db.CommunityMembers.AnyAsync(m => m.CommunityId == community.Id && m.UserId == targetId)).Should().BeFalse();
+
+        (await ctx.Db.Rooms.FindAsync(room.Id))!.MembersCount.Should().Be(1);
+        (await ctx.Db.Clubs.FindAsync(club.Id))!.MembersCount.Should().Be(1);
+        (await ctx.Db.Communities.FindAsync(community.Id))!.MembersCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task KickRoomMemberAsync_ShouldReturnForbidden_WhenModeratorTargetsPeer()
+    {
+        await using var ctx = await RoomServiceTestContext.CreateAsync();
+        var actorId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        var community = SeedCommunity(ctx, actorId);
+        var club = SeedClub(ctx, community.Id, actorId);
+        var room = SeedRoom(ctx, club.Id, actorId, RoomJoinPolicy.Open, membersCount: 2);
+
+        SeedMember(ctx, room.Id, actorId, RoomRole.Moderator, RoomMemberStatus.Approved);
+        SeedMember(ctx, room.Id, targetId, RoomRole.Moderator, RoomMemberStatus.Approved);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.KickRoomMemberAsync(room.Id, targetId, actorId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Forbidden);
+    }
+
+    [Fact]
+    public async Task KickRoomMemberAsync_ShouldReturnForbidden_WhenTargetIsRoomOwner()
+    {
+        await using var ctx = await RoomServiceTestContext.CreateAsync();
+        var actorId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        var community = SeedCommunity(ctx, actorId);
+        var club = SeedClub(ctx, community.Id, actorId);
+        var room = SeedRoom(ctx, club.Id, actorId, RoomJoinPolicy.Open, membersCount: 2);
+
+        SeedMember(ctx, room.Id, actorId, RoomRole.Owner, RoomMemberStatus.Approved);
+        SeedMember(ctx, room.Id, targetId, RoomRole.Owner, RoomMemberStatus.Approved);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.KickRoomMemberAsync(room.Id, targetId, actorId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Forbidden);
+    }
+
+    [Fact]
+    public async Task KickRoomMemberAsync_ShouldReturnValidation_WhenActorKicksSelf()
+    {
+        await using var ctx = await RoomServiceTestContext.CreateAsync();
+        var userId = Guid.NewGuid();
+
+        var community = SeedCommunity(ctx, userId);
+        var club = SeedClub(ctx, community.Id, userId);
+        var room = SeedRoom(ctx, club.Id, userId, RoomJoinPolicy.Open, membersCount: 1);
+
+        SeedMember(ctx, room.Id, userId, RoomRole.Owner, RoomMemberStatus.Approved);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.KickRoomMemberAsync(room.Id, userId, userId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Validation);
+    }
+
+    [Fact]
+    public async Task KickRoomMemberAsync_ShouldSucceed_WhenTargetAlreadyRemoved()
+    {
+        await using var ctx = await RoomServiceTestContext.CreateAsync();
+        var ownerId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        var community = SeedCommunity(ctx, ownerId);
+        community.MembersCount = 2;
+        var club = SeedClub(ctx, community.Id, ownerId);
+        club.MembersCount = 2;
+        var room = SeedRoom(ctx, club.Id, ownerId, RoomJoinPolicy.Open, membersCount: 2);
+
+        SeedCommunityMember(ctx, community.Id, ownerId, MemberRole.Owner);
+        SeedCommunityMember(ctx, community.Id, targetId, MemberRole.Member);
+        SeedClubMember(ctx, club.Id, ownerId, MemberRole.Owner);
+        SeedClubMember(ctx, club.Id, targetId, MemberRole.Member);
+        SeedMember(ctx, room.Id, ownerId, RoomRole.Owner, RoomMemberStatus.Approved);
+        SeedMember(ctx, room.Id, targetId, RoomRole.Member, RoomMemberStatus.Approved);
+        await ctx.Db.SaveChangesAsync();
+
+        (await ctx.Service.KickRoomMemberAsync(room.Id, targetId, ownerId)).IsSuccess.Should().BeTrue();
+        var second = await ctx.Service.KickRoomMemberAsync(room.Id, targetId, ownerId);
+
+        second.IsSuccess.Should().BeTrue();
+        (await ctx.Db.RoomMembers.AnyAsync(m => m.RoomId == room.Id && m.UserId == targetId)).Should().BeFalse();
+        (await ctx.Db.ClubMembers.AnyAsync(m => m.ClubId == club.Id && m.UserId == targetId)).Should().BeFalse();
+        (await ctx.Db.CommunityMembers.AnyAsync(m => m.CommunityId == community.Id && m.UserId == targetId)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task KickRoomMemberAsync_ShouldRollback_WhenTargetIsClubOwner()
+    {
+        await using var ctx = await RoomServiceTestContext.CreateAsync();
+        var ownerId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        var community = SeedCommunity(ctx, ownerId);
+        community.MembersCount = 2;
+        var club = SeedClub(ctx, community.Id, ownerId);
+        club.MembersCount = 2;
+        var room = SeedRoom(ctx, club.Id, ownerId, RoomJoinPolicy.Open, membersCount: 2);
+
+        SeedCommunityMember(ctx, community.Id, ownerId, MemberRole.Owner);
+        SeedCommunityMember(ctx, community.Id, targetId, MemberRole.Member);
+        SeedClubMember(ctx, club.Id, ownerId, MemberRole.Owner);
+        SeedClubMember(ctx, club.Id, targetId, MemberRole.Owner);
+        SeedMember(ctx, room.Id, ownerId, RoomRole.Owner, RoomMemberStatus.Approved);
+        SeedMember(ctx, room.Id, targetId, RoomRole.Member, RoomMemberStatus.Approved);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.KickRoomMemberAsync(room.Id, targetId, ownerId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Forbidden);
+
+        (await ctx.Db.RoomMembers.AnyAsync(m => m.RoomId == room.Id && m.UserId == targetId)).Should().BeTrue();
+        (await ctx.Db.ClubMembers.AnyAsync(m => m.ClubId == club.Id && m.UserId == targetId)).Should().BeTrue();
+        (await ctx.Db.Clubs.FindAsync(club.Id))!.MembersCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task KickRoomMemberAsync_ShouldRollback_WhenTargetIsCommunityOwner()
+    {
+        await using var ctx = await RoomServiceTestContext.CreateAsync();
+        var ownerId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        var community = SeedCommunity(ctx, ownerId);
+        community.MembersCount = 2;
+        var club = SeedClub(ctx, community.Id, ownerId);
+        club.MembersCount = 2;
+        var room = SeedRoom(ctx, club.Id, ownerId, RoomJoinPolicy.Open, membersCount: 2);
+
+        SeedCommunityMember(ctx, community.Id, ownerId, MemberRole.Owner);
+        SeedCommunityMember(ctx, community.Id, targetId, MemberRole.Owner);
+        SeedClubMember(ctx, club.Id, ownerId, MemberRole.Owner);
+        SeedClubMember(ctx, club.Id, targetId, MemberRole.Member);
+        SeedMember(ctx, room.Id, ownerId, RoomRole.Owner, RoomMemberStatus.Approved);
+        SeedMember(ctx, room.Id, targetId, RoomRole.Member, RoomMemberStatus.Approved);
+        await ctx.Db.SaveChangesAsync();
+
+        var result = await ctx.Service.KickRoomMemberAsync(room.Id, targetId, ownerId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Code.Should().Be(Error.Codes.Forbidden);
+
+        (await ctx.Db.RoomMembers.AnyAsync(m => m.RoomId == room.Id && m.UserId == targetId)).Should().BeTrue();
+        (await ctx.Db.CommunityMembers.AnyAsync(m => m.CommunityId == community.Id && m.UserId == targetId)).Should().BeTrue();
+        (await ctx.Db.Communities.FindAsync(community.Id))!.MembersCount.Should().Be(2);
+    }
+
     private static Community SeedCommunity(RoomServiceTestContext ctx, Guid createdBy)
     {
         var community = new Community
@@ -166,6 +354,30 @@ public sealed class RoomServiceTests
         ctx.Db.RoomMembers.Add(member);
     }
 
+    private static void SeedClubMember(RoomServiceTestContext ctx, Guid clubId, Guid userId, MemberRole role)
+    {
+        var member = new ClubMember
+        {
+            ClubId = clubId,
+            UserId = userId,
+            Role = role,
+            JoinedAt = DateTime.UtcNow
+        };
+        ctx.Db.ClubMembers.Add(member);
+    }
+
+    private static void SeedCommunityMember(RoomServiceTestContext ctx, Guid communityId, Guid userId, MemberRole role)
+    {
+        var member = new CommunityMember
+        {
+            CommunityId = communityId,
+            UserId = userId,
+            Role = role,
+            JoinedAt = DateTime.UtcNow
+        };
+        ctx.Db.CommunityMembers.Add(member);
+    }
+
     private sealed class RoomServiceTestContext : IAsyncDisposable
     {
         private readonly SqliteConnection _connection;
@@ -197,8 +409,21 @@ public sealed class RoomServiceTests
             var uow = new UnitOfWork(db, factory);
             var queryRepo = new RoomQueryRepository(db);
             var commandRepo = new RoomCommandRepository(db);
+            var clubQuery = new ClubQueryRepository(db);
+            var clubCommand = new ClubCommandRepository(db);
+            var communityQuery = new CommunityQueryRepository(db);
+            var communityCommand = new CommunityCommandRepository(db);
             var passwordHasher = new PasswordHasher<Room>();
-            var service = new RoomService(uow, queryRepo, commandRepo, passwordHasher);
+            var service = new RoomService(
+                uow,
+                queryRepo,
+                commandRepo,
+                clubQuery,
+                clubCommand,
+                communityQuery,
+                communityCommand,
+                passwordHasher,
+                NullLogger<RoomService>.Instance);
 
             return new RoomServiceTestContext(connection, uow)
             {


### PR DESCRIPTION
## Summary
- enforce hierarchical room moderation rules and prevent self-removal when kicking members
- cascade room member removals to club and community memberships with logging
- expand unit tests to cover new authorization paths and cascade behavior, updating test contexts for the new dependencies

## Testing
- `dotnet test Tests/Services.Rooms.Tests/Services.Rooms.Tests.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f9ea7d825c832d964b6ef2e181c2c3