### PR TITLE
Fix duplicate ChatHub mapping and guard realtime configuration

### DIFF
--- a/WebAPI/Extensions/ApplicationBuilderExtensions.cs
+++ b/WebAPI/Extensions/ApplicationBuilderExtensions.cs
@@ -14,9 +14,6 @@ public static class ApplicationBuilderExtensions
         app.UseAuthentication();
         app.UseAuthorization();
 
-        // Map SignalR Hubs
-        app.MapHub<WebAPI.Hubs.ChatHub>("/ws/chat");
-
         app.MapControllers();
 
         // Map OpenAPI and documentation AFTER all endpoints are mapped

--- a/WebAPI/Extensions/RealtimeExtensions.cs
+++ b/WebAPI/Extensions/RealtimeExtensions.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using WebApi.Options;
+using WebAPI.Hubs;
+
+namespace WebApi.Extensions;
+
+public static class RealtimeExtensions
+{
+    public static IServiceCollection AddRealtime(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSignalR();
+
+        services.AddOptions<RealtimeOptions>()
+            .Bind(configuration.GetSection(RealtimeOptions.SectionName))
+            .Validate(options => !string.IsNullOrWhiteSpace(options.ChatPath),
+                $"{nameof(RealtimeOptions.ChatPath)} must be provided.");
+
+        return services;
+    }
+
+    public static WebApplication MapRealtimeEndpoints(this WebApplication app)
+    {
+        var options = app.Services.GetRequiredService<IOptions<RealtimeOptions>>().Value;
+        var chatPath = options.ChatPath;
+
+        app.MapHub<PresenceHub>("/ws/presence");
+        app.MapHub<ChatHub>(chatPath);
+
+        if (app.Environment.IsDevelopment())
+        {
+            var endpointSources = app.Services.GetRequiredService<IEnumerable<EndpointDataSource>>();
+            var negotiatePath = $"{chatPath}/negotiate".TrimEnd('/');
+            var duplicateCount = endpointSources
+                .SelectMany(source => source.Endpoints)
+                .OfType<RouteEndpoint>()
+                .Count(endpoint =>
+                {
+                    var rawText = endpoint.RoutePattern.RawText;
+
+                    return !string.IsNullOrWhiteSpace(rawText)
+                        && string.Equals(rawText.TrimEnd('/'), negotiatePath, StringComparison.OrdinalIgnoreCase);
+                });
+
+            if (duplicateCount > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Multiple negotiate endpoints detected for chat hub path '{chatPath}'. Ensure the chat hub is mapped only once.");
+            }
+        }
+
+        return app;
+    }
+}

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -19,8 +19,6 @@ public static class ServiceCollectionExtensions
                 o.JsonSerializerOptions.PropertyNamingPolicy = null;
             });
 
-        services.AddSignalR();
-
         // Ensure API explorer for controllers is available for OpenAPI/Scalar
         services.AddEndpointsApiExplorer();
 

--- a/WebAPI/Options/RealtimeOptions.cs
+++ b/WebAPI/Options/RealtimeOptions.cs
@@ -1,0 +1,37 @@
+namespace WebApi.Options;
+
+public sealed class RealtimeOptions
+{
+    public const string SectionName = "Realtime";
+    public const string DefaultChatPath = "/ws/chat";
+
+    private string _chatPath = DefaultChatPath;
+
+    public string ChatPath
+    {
+        get => _chatPath;
+        set => _chatPath = NormalizePath(value);
+    }
+
+    private static string NormalizePath(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return DefaultChatPath;
+        }
+
+        var path = value.Trim();
+
+        if (!path.StartsWith('/'))
+        {
+            path = $"/{path}";
+        }
+
+        if (path.Length > 1)
+        {
+            path = path.TrimEnd('/');
+        }
+
+        return path;
+    }
+}

--- a/WebAPI/Program.cs
+++ b/WebAPI/Program.cs
@@ -1,5 +1,3 @@
-using WebAPI.Hubs;
-
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 
 var builder = WebApplication.CreateBuilder(args);
@@ -19,6 +17,7 @@ if (!builder.Environment.IsDevelopment())
 builder.Services.AddEmailing(builder.Configuration);
 builder.Services
     .AddWebApi(builder.Configuration)
+    .AddRealtime(builder.Configuration)
     .AddOperationalServices(builder.Configuration)
     .AddDataLayer(builder.Configuration)
     .AddJwtAuth<User>(builder.Configuration)
@@ -32,7 +31,6 @@ var app = builder.Build();
 app.UseOperationalPipeline(app.Environment);
 app.UseWebApi(app.Environment);
 
-app.MapHub<PresenceHub>("/ws/presence");
-app.MapHub<ChatHub>("/ws/chat");
+app.MapRealtimeEndpoints();
 
 app.Run();


### PR DESCRIPTION
## Summary
- centralize realtime service registration and endpoint mapping via new realtime extensions and options
- remove the extra ChatHub mapping from the shared WebAPI middleware pipeline while keeping presence hub support
- add a development-time endpoint guard to fail fast if duplicate negotiate routes are introduced

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f9fae6d8dc832da4549dc7e18485b0