### PR TITLE
Allow public community viewing and fix SignalR CORS

### DIFF
--- a/DTOs/Clubs/ClubDetailDto.cs
+++ b/DTOs/Clubs/ClubDetailDto.cs
@@ -13,6 +13,7 @@ public sealed record ClubDetailDto(
     int RoomsCount,
     Guid OwnerId,
     bool IsMember,
+    bool IsCommunityMember,
     bool IsOwner,
     DateTime CreatedAtUtc,
     DateTime? UpdatedAtUtc

--- a/Repositories/Implements/ClubQueryRepository.cs
+++ b/Repositories/Implements/ClubQueryRepository.cs
@@ -131,6 +131,8 @@ public sealed class ClubQueryRepository : IClubQueryRepository
                     .FirstOrDefault(),
                 currentUserId.HasValue && _context.ClubMembers
                     .Any(cm => cm.ClubId == c.Id && cm.UserId == currentUserId.Value),
+                currentUserId.HasValue && _context.CommunityMembers
+                    .Any(cm => cm.CommunityId == c.CommunityId && cm.UserId == currentUserId.Value),
                 currentUserId.HasValue && _context.ClubMembers
                     .Any(cm => cm.ClubId == c.Id && cm.UserId == currentUserId.Value && cm.Role == MemberRole.Owner),
                 c.CreatedAtUtc,

--- a/Repositories/Models/ClubDetailModel.cs
+++ b/Repositories/Models/ClubDetailModel.cs
@@ -10,6 +10,7 @@ public sealed record ClubDetailModel(
     int RoomsCount,
     Guid OwnerId,
     bool IsMember,
+    bool IsCommunityMember,
     bool IsOwner,
     DateTime CreatedAtUtc,
     DateTime? UpdatedAtUtc

--- a/Services/Common/Mapping/ClubMappers.cs
+++ b/Services/Common/Mapping/ClubMappers.cs
@@ -41,6 +41,7 @@ public static class ClubMappers
             model.RoomsCount,
             model.OwnerId,
             model.IsMember,
+            model.IsCommunityMember,
             model.IsOwner,
             model.CreatedAtUtc,
             model.UpdatedAtUtc

--- a/Services/Interfaces/IClubService.cs
+++ b/Services/Interfaces/IClubService.cs
@@ -26,6 +26,7 @@ public interface IClubService
         int? membersFrom,
         int? membersTo,
         CursorRequest cursor,
+        Guid? currentUserId = null,
         CancellationToken ct = default);
 
     Task<Result<ClubDetailDto>> CreateClubAsync(ClubCreateRequestDto req, Guid currentUserId, CancellationToken ct = default);

--- a/WebAPI/Controllers/ClubsController.cs
+++ b/WebAPI/Controllers/ClubsController.cs
@@ -69,6 +69,8 @@ public sealed class ClubsController : ControllerBase
             Desc: true  // DESC order
         );
 
+        var currentUserId = User.GetUserId();
+
         var result = await _clubService.SearchAsync(
             communityId,
             name,
@@ -76,6 +78,7 @@ public sealed class ClubsController : ControllerBase
             membersFrom,
             membersTo,
             cursorRequest,
+            currentUserId,
             ct);
 
         return this.ToActionResult(result, successStatus: StatusCodes.Status200OK);
@@ -129,7 +132,7 @@ public sealed class ClubsController : ControllerBase
     }
 
     /// <summary>
-    /// Join a club. Requires community membership and is idempotent if already joined.
+    /// Join a club. Idempotent if already joined.
     /// </summary>
     [HttpPost("{clubId:guid}/join")]
     [EnableRateLimiting("ClubsWrite")]

--- a/WebAPI/Extensions/RealtimeExtensions.cs
+++ b/WebAPI/Extensions/RealtimeExtensions.cs
@@ -30,8 +30,8 @@ public static class RealtimeExtensions
         var options = app.Services.GetRequiredService<IOptions<RealtimeOptions>>().Value;
         var chatPath = options.ChatPath;
 
-        app.MapHub<PresenceHub>("/ws/presence");
-        app.MapHub<ChatHub>(chatPath);
+        app.MapHub<PresenceHub>("/ws/presence").RequireCors("Default");
+        app.MapHub<ChatHub>(chatPath).RequireCors("Default");
 
         if (app.Environment.IsDevelopment())
         {


### PR DESCRIPTION
## Summary
- gate community and club read operations by community visibility while allowing non-members to browse public communities
- expose club viewer state and add audit logging for non-member access and joins without community membership
- apply the shared CORS policy to SignalR hubs to resolve negotiate failures from the SPA

## Testing
- `dotnet test StudentGamerHub.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f9fe4de8ec832d9186caf922867882