### PR TITLE
Fix CORS configuration for SignalR negotiation

### DIFF
--- a/WebAPI/Extensions/ApplicationBuilderExtensions.cs
+++ b/WebAPI/Extensions/ApplicationBuilderExtensions.cs
@@ -9,6 +9,7 @@ public static class ApplicationBuilderExtensions
         app.UseExceptionHandler();
 
         app.UseHttpsRedirection();
+        app.UseRouting();
         app.UseCors("Default");
         app.UseRateLimiter();
         app.UseAuthentication();

--- a/WebAPI/appsettings.Development.json
+++ b/WebAPI/appsettings.Development.json
@@ -43,8 +43,12 @@
     "AllowedOrigins": [
       "https://localhost:7163",
       "https://fe-student-gamer-hub.vercel.app",
-      "http://localhost:5173"
+      "http://localhost:5173",
+      "https://studentgamerhub.rf.gd"
     ]
+  },
+  "Realtime": {
+    "ChatPath": "/ws/chat"
   },
   "JwtSettings": {
     "ValidAudience": "UserManager",

--- a/WebAPI/appsettings.Production.json
+++ b/WebAPI/appsettings.Production.json
@@ -1,4 +1,14 @@
 {
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:5173",
+      "https://fe-student-gamer-hub.vercel.app",
+      "https://studentgamerhub.rf.gd"
+    ]
+  },
+  "Realtime": {
+    "ChatPath": "/ws/chat"
+  },
   "PayOS": {
     "ClientId": "xxx",
     "ApiKey": "yyy",


### PR DESCRIPTION
## Summary
- bind the default CORS policy to explicit origins from configuration and enable credentials for REST and SignalR
- ensure the web pipeline routes before applying CORS and add environment-specific chat hub configuration for the allowed origins

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa33c9fb50832d90354f7e78e283ea