### PR TITLE
Fix SignalR CORS negotiation and JWT handling

### DIFF
--- a/WebAPI/Extensions/RealtimeExtensions.cs
+++ b/WebAPI/Extensions/RealtimeExtensions.cs
@@ -30,11 +30,15 @@ public static class RealtimeExtensions
         var options = app.Services.GetRequiredService<IOptions<RealtimeOptions>>().Value;
         var chatPath = options.ChatPath;
 
-        app.MapHub<PresenceHub>("/ws/presence").RequireCors("Default");
-        app.MapHub<ChatHub>(chatPath).RequireCors("Default");
+        const string corsPolicyName = "Frontend";
+
+        app.MapHub<PresenceHub>("/ws/presence").RequireCors(corsPolicyName);
+        app.MapHub<ChatHub>(chatPath).RequireCors(corsPolicyName);
 
         if (app.Environment.IsDevelopment())
         {
+            app.Logger.LogInformation("Realtime chat hub path resolved to {ChatPath}.", chatPath);
+
             var endpointSources = app.Services.GetRequiredService<IEnumerable<EndpointDataSource>>();
             var negotiatePath = $"{chatPath}/negotiate".TrimEnd('/');
             var duplicateCount = endpointSources

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -435,27 +435,15 @@ public static class ServiceCollectionExtensions
 
         services.AddCors(opt =>
         {
-            opt.AddPolicy("Default", p =>
+            opt.AddPolicy("Frontend", p =>
             {
-                // Read allowed origins from configuration: Cors:AllowedOrigins as string[]
-                var allowedOrigins = configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
-                                     ?? Array.Empty<string>();
-
-                if (allowedOrigins.Length == 0 || Array.Exists(allowedOrigins, o => o == "*"))
-                {
-                    // Fallback: allow any origin (no credentials allowed with wildcard)
-                    p.AllowAnyOrigin()
-                     .AllowAnyHeader()
-                     .AllowAnyMethod();
-                }
-                else
-                {
-                    // Explicit origins: allow credentials for SPA auth/cookies if needed
-                    p.WithOrigins(allowedOrigins)
-                     .AllowAnyHeader()
-                     .AllowAnyMethod()
-                     .AllowCredentials();
-                }
+                p.WithOrigins(
+                        "http://localhost:5173",
+                        "http://127.0.0.1:5173",
+                        "https://fe-student-gamer-hub.vercel.app")
+                 .WithMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                 .AllowAnyHeader()
+                 .AllowCredentials();
             });
         });
 

--- a/WebAPI/Security/JwtExtensions.cs
+++ b/WebAPI/Security/JwtExtensions.cs
@@ -1,86 +1,102 @@
-﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.IdentityModel.Tokens;
+using System;
 using System.Security.Claims;
 using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using WebApi.Options;
 
 public static class JwtExtensions
 {
     public static IServiceCollection AddJwtAuth<TUser>(this IServiceCollection services, IConfiguration config)
-            where TUser : IdentityUser<Guid>
-
+        where TUser : IdentityUser<Guid>
     {
         services.AddOptions<JwtSettings>()
-        .Bind(config.GetSection(JwtSettings.SectionName))
-        .Validate(s => !string.IsNullOrWhiteSpace(s.Key), "JwtSettings:Key is required")
-        .Validate(s => !string.IsNullOrWhiteSpace(s.ValidIssuer), "JwtSettings:ValidIssuer is required")
-        .Validate(s => !string.IsNullOrWhiteSpace(s.ValidAudience), "JwtSettings:ValidAudience is required")
-        .ValidateOnStart();
-
+            .Bind(config.GetSection(JwtSettings.SectionName))
+            .Validate(s => !string.IsNullOrWhiteSpace(s.Key), "JwtSettings:Key is required")
+            .Validate(s => !string.IsNullOrWhiteSpace(s.ValidIssuer), "JwtSettings:ValidIssuer is required")
+            .Validate(s => !string.IsNullOrWhiteSpace(s.ValidAudience), "JwtSettings:ValidAudience is required")
+            .ValidateOnStart();
 
         var jwt = config.GetSection(JwtSettings.SectionName).Get<JwtSettings>()!;
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.Key));
 
-
         services
-        .AddAuthentication(options =>
-        {
-            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-        })
-        .AddJwtBearer(options =>
-        {
-            options.RequireHttpsMetadata = true;
-            options.SaveToken = false;
-            options.TokenValidationParameters = new TokenValidationParameters
+            .AddAuthentication(options =>
             {
-                ValidateIssuer = true,
-                ValidIssuer = jwt.ValidIssuer,
-                ValidateAudience = true,
-                ValidAudience = jwt.ValidAudience,
-                ValidateIssuerSigningKey = true,
-                IssuerSigningKey = key,
-                ValidateLifetime = true,
-                ClockSkew = TimeSpan.Zero,
-                NameClaimType = ClaimTypes.Name,
-                RoleClaimType = ClaimTypes.Role
-            };
-
-
-            // 🔐 SecurityStamp guard: vô hiệu hoá access token cũ sau khi revoke/change pwd
-            options.Events = new JwtBearerEvents
+                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+            })
+            .AddJwtBearer(options =>
             {
-                OnTokenValidated = async ctx =>
+                options.RequireHttpsMetadata = true;
+                options.SaveToken = false;
+                options.TokenValidationParameters = new TokenValidationParameters
                 {
-                    var userId = ctx.Principal?.FindFirstValue(ClaimTypes.NameIdentifier);
-                    var tokenSst = ctx.Principal?.FindFirst("sst")?.Value; // SecurityStamp lúc phát hành
-                    if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(tokenSst))
+                    ValidateIssuer = true,
+                    ValidIssuer = jwt.ValidIssuer,
+                    ValidateAudience = true,
+                    ValidAudience = jwt.ValidAudience,
+                    ValidateIssuerSigningKey = true,
+                    IssuerSigningKey = key,
+                    ValidateLifetime = true,
+                    ClockSkew = TimeSpan.Zero,
+                    NameClaimType = ClaimTypes.Name,
+                    RoleClaimType = ClaimTypes.Role
+                };
+
+                options.Events = new JwtBearerEvents
+                {
+                    OnMessageReceived = ctx =>
                     {
-                        ctx.Fail("Missing required claims.");
-                        return;
-                    }
+                        var accessToken = ctx.Request.Query["access_token"];
 
+                        if (!string.IsNullOrEmpty(accessToken))
+                        {
+                            var realtimeOptions = ctx.HttpContext.RequestServices.GetService<IOptions<RealtimeOptions>>();
+                            var chatPath = realtimeOptions?.Value.ChatPath ?? RealtimeOptions.DefaultChatPath;
 
-                    var um = ctx.HttpContext.RequestServices.GetRequiredService<UserManager<TUser>>();
-                    var user = await um.FindByIdAsync(userId);
-                    if (user is null)
+                            if (!string.IsNullOrWhiteSpace(chatPath) &&
+                                ctx.HttpContext.Request.Path.StartsWithSegments(new PathString(chatPath), StringComparison.OrdinalIgnoreCase))
+                            {
+                                ctx.Token = accessToken;
+                            }
+                        }
+
+                        return Task.CompletedTask;
+                    },
+                    OnTokenValidated = async ctx =>
                     {
-                        ctx.Fail("User not found.");
-                        return;
+                        var userId = ctx.Principal?.FindFirstValue(ClaimTypes.NameIdentifier);
+                        var tokenSst = ctx.Principal?.FindFirst("sst")?.Value; // SecurityStamp lúc phát hành
+                        if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(tokenSst))
+                        {
+                            ctx.Fail("Missing required claims.");
+                            return;
+                        }
+
+                        var um = ctx.HttpContext.RequestServices.GetRequiredService<UserManager<TUser>>();
+                        var user = await um.FindByIdAsync(userId);
+                        if (user is null)
+                        {
+                            ctx.Fail("User not found.");
+                            return;
+                        }
+
+                        var currentSst = await um.GetSecurityStampAsync(user);
+                        if (!string.Equals(tokenSst, currentSst, StringComparison.Ordinal))
+                        {
+                            // SecurityStamp đã thay đổi → token này trở nên vô hiệu
+                            ctx.Fail("Token security stamp mismatch.");
+                            return;
+                        }
                     }
-
-
-                    var currentSst = await um.GetSecurityStampAsync(user);
-                    if (!string.Equals(tokenSst, currentSst, StringComparison.Ordinal))
-                    {
-                        // SecurityStamp đã thay đổi → token này trở nên vô hiệu
-                        ctx.Fail("Token security stamp mismatch.");
-                        return;
-                    }
-                }
-            };
-        });
-
+                };
+            });
 
         services.AddAuthorization();
         return services;


### PR DESCRIPTION
## Summary
- add a dedicated Frontend CORS policy with the required origins and apply it in the middleware pipeline
- require the new policy for SignalR hubs, log the resolved chat hub path, and keep a single hub mapping
- extend JWT bearer authentication to read access tokens from SignalR query strings while preserving validation

## Testing
- dotnet build WebAPI/WebAPI.csproj *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa4d5b956c832db600af1314e167ce