### PR TITLE
Fix quest sync on event attendance and restrict user game seeding

### DIFF
--- a/Repositories/Persistence/Seeding/AppSeeder.cs
+++ b/Repositories/Persistence/Seeding/AppSeeder.cs
@@ -330,7 +330,10 @@ public sealed class AppSeeder : IAppSeeder
 
         var users = await _db.Users
             .AsNoTracking()
-            .Where(u => !u.IsDeleted)
+            .Where(u => !u.IsDeleted
+                        && u.Email != null
+                        && u.Email.StartsWith("user")
+                        && u.Email.EndsWith("@example.com"))
             .OrderBy(u => u.CreatedAtUtc)
             .Select(u => new { u.Id })
             .ToListAsync(ct);


### PR DESCRIPTION
## Summary
- trigger the ATTEND_EVENT quest when ticket confirmations succeed through wallet or PayOS flows
- add best-effort quest completion helper methods for payment confirmation paths
- limit UserGame seeding to sample accounts so real users no longer receive default games

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fafb92c5d0832dbc3c54af1d89882b